### PR TITLE
Downgrade contributor-assistant from v2.4.0 to v2.3.2

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
-      - uses: contributor-assistant/github-action@v2.4.0
+      - uses: contributor-assistant/github-action@v2.3.2
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To avoid a bug of contributor-assistant v2.4.0
https://github.com/contributor-assistant/github-action/issues/155