### PR TITLE
Downgrade contributor-assistant from v2.3.2 to v2.3.1

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,11 +16,10 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
-      - uses: contributor-assistant/github-action@v2.3.2
+      - uses: contributor-assistant/github-action@v2.3.1
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/arktwin/arktwin/blob/main/CLA.md


### PR DESCRIPTION
Continue with https://github.com/arktwin/arktwin/pull/4