### PR TITLE
Rename arktwin_edge_rest_simulation_latency to arktwin_edge_rest_virtual_latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Some configuration can be overridden using environment variables.
   - arktwin_edge_rest_agent_num {endpoint, edge_id, run_id}
   - arktwin_edge_rest_request_num {endpoint, edge_id, run_id}
   - arktwin_edge_rest_process_machine_time {endpoint, edge_id, run_id}
-  - arktwin_edge_rest_simulation_latency {endpoint, edge_id, run_id}
+  - arktwin_edge_rest_virtual_latency {endpoint, edge_id, run_id}
 - Other metrics
   - arktwin_center_dead_letter_num {recipient, edge_id, run_id}
   - arktwin_edge_dead_letter_num {recipient, edge_id, run_id}


### PR DESCRIPTION
Implementation has already done in 1c7377e77382a0c3d00eec5a88f77020f8bbb93e.