### PR TITLE
Add lineEndings configuration

### DIFF
--- a/arktwin/.scalafmt.conf
+++ b/arktwin/.scalafmt.conf
@@ -1,6 +1,7 @@
 version = 3.8.5
 runner.dialect = scala3
 maxColumn = 100
+lineEndings = unix
 
 rewrite.rules = [SortModifiers]
 rewrite.scala3 {


### PR DESCRIPTION
Prevent line endings from becoming CRLF when running on a Windows machine.
ref. https://scalameta.org/scalafmt/docs/configuration.html#lineendings