### PR TITLE
Add Trace Logs

### DIFF
--- a/arktwin/center/src/main/resources/pekko.conf
+++ b/arktwin/center/src/main/resources/pekko.conf
@@ -6,7 +6,6 @@ pekko {
   }
 
   loglevel = info
-  loglevel = ${?ARKTWIN_CENTER_STATIC_LOG_LEVEL}
   log-config-on-start = off
   log-dead-letters = 0
 

--- a/arktwin/center/src/main/resources/reference.conf
+++ b/arktwin/center/src/main/resources/reference.conf
@@ -44,10 +44,11 @@ arktwin {
       portAutoIncrement = ${?ARKTWIN_CENTER_STATIC_PORT_AUTO_INCREMENT}
       portAutoIncrementMax = 100
       portAutoIncrementMax = ${?ARKTWIN_CENTER_STATIC_PORT_AUTO_INCREMENT_MAX}
-      logLevel = info
+      logLevel = Info
       logLevel = ${?ARKTWIN_CENTER_STATIC_LOG_LEVEL}
       logLevelColor = true
       logLevelColor = ${?ARKTWIN_CENTER_STATIC_LOG_LEVEL_COLOR}
+      logSuppressionList = []
       actorTimeout = 10s
       subscribeBatchSize = 100
       subscribeBatchInterval = 10ms

--- a/arktwin/center/src/main/scala/arktwin/center/Center.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/Center.scala
@@ -45,7 +45,7 @@ object Center:
     given Timeout = config.static.actorTimeout
 
     scribe.info(BuildInfo.toString)
-    scribe.info(config.toString)
+    scribe.info(config.toJson)
     scribe.debug(rawConfig.toString)
 
     val runId = issueRunId(config.static.runIdPrefix)

--- a/arktwin/center/src/main/scala/arktwin/center/Center.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/Center.scala
@@ -28,7 +28,11 @@ object Center:
     val config = CenterConfig.loadOrThrow()
     val rawConfig = CenterConfig.loadRawOrThrow()
 
-    LoggerConfigurator.init(config.static.logLevel, config.static.logLevelColor)
+    LoggerConfigurator.init(
+      config.static.logLevel,
+      config.static.logLevelColor,
+      config.static.logSuppressionList
+    )
     Kamon.init(rawConfig)
 
     given actorSystem: ActorSystem[SpawnProtocol.Command] = ActorSystem(

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
@@ -6,6 +6,7 @@ import arktwin.center.actors.ChartRecorder.ChartRecord
 import arktwin.center.configs.AtlasConfig
 import arktwin.center.util.CenterKamon
 import arktwin.center.util.CommonMessages.Timeout
+import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -47,7 +48,7 @@ object Atlas:
   def apply(
       config: AtlasConfig,
       kamon: CenterKamon
-  ): Behavior[Message] = Behaviors.setup: context =>
+  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
     Behaviors.withTimers: timer =>
       timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateInterval)
 
@@ -67,7 +68,7 @@ object Atlas:
           replyTo ! chart
           context.watchWith(chart, RemoveChart(edgeId))
           charts += edgeId -> chart
-          context.log.info(s"spawned a chart for $edgeId: ${chart.path}")
+          scribe.info(s"spawned a chart for $edgeId: ${chart.path}")
           Behaviors.same
 
         case RemoveChart(edgeId) =>
@@ -82,7 +83,7 @@ object Atlas:
           replyTo ! chartRecorder
           context.watchWith(chartRecorder, RemoveChartRecorder(edgeId))
           chartRecorders += edgeId -> chartRecorder
-          context.log.info(s"spawned a chart recorder for $edgeId: ${chartRecorder.path} ")
+          scribe.info(s"spawned a chart recorder for $edgeId: ${chartRecorder.path} ")
           Behaviors.same
 
         case RemoveChartRecorder(edgeId) =>
@@ -119,7 +120,7 @@ object Atlas:
       charts: Map[String, ActorRef[Chart.Message]],
       chartSubscribers: Map[String, ActorRef[Chart.SubscribeBatch]],
       config: AtlasConfig
-  ): Behavior[ChartRecord | Timeout.type] = Behaviors.setup: context =>
+  ): Behavior[ChartRecord | Timeout.type] = Behaviors.setupWithScribeMdc: context =>
     Behaviors.withTimers: timer =>
       config.culling match
         case AtlasConfig.Broadcast() =>
@@ -172,7 +173,7 @@ object Atlas:
               )
               for (edgeId, chart) <- charts do chart ! updateRouteTable
 
-              context.log.debug(
+              scribe.debug(
                 partitionToSubscriber.toSeq
                   .sortBy((index, _) => (index.x, index.y, index.z))
                   .map((i, senders) =>

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
@@ -6,7 +6,7 @@ import arktwin.center.actors.ChartRecorder.ChartRecord
 import arktwin.center.configs.AtlasConfig
 import arktwin.center.util.CenterKamon
 import arktwin.center.util.CommonMessages.Timeout
-import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
+import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -48,7 +48,7 @@ object Atlas:
   def apply(
       config: AtlasConfig,
       kamon: CenterKamon
-  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
+  ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
     Behaviors.withTimers: timer =>
       timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateInterval)
 
@@ -68,7 +68,7 @@ object Atlas:
           replyTo ! chart
           context.watchWith(chart, RemoveChart(edgeId))
           charts += edgeId -> chart
-          scribe.info(s"spawned a chart for $edgeId: ${chart.path}")
+          logger.info(s"spawned a chart for $edgeId: ${chart.path}")
           Behaviors.same
 
         case RemoveChart(edgeId) =>
@@ -83,7 +83,7 @@ object Atlas:
           replyTo ! chartRecorder
           context.watchWith(chartRecorder, RemoveChartRecorder(edgeId))
           chartRecorders += edgeId -> chartRecorder
-          scribe.info(s"spawned a chart recorder for $edgeId: ${chartRecorder.path} ")
+          logger.info(s"spawned a chart recorder for $edgeId: ${chartRecorder.path} ")
           Behaviors.same
 
         case RemoveChartRecorder(edgeId) =>
@@ -120,7 +120,7 @@ object Atlas:
       charts: Map[String, ActorRef[Chart.Message]],
       chartSubscribers: Map[String, ActorRef[Chart.SubscribeBatch]],
       config: AtlasConfig
-  ): Behavior[ChartRecord | Timeout.type] = Behaviors.setupWithScribeMdc: context =>
+  ): Behavior[ChartRecord | Timeout.type] = Behaviors.setupWithLogger: (context, logger) =>
     Behaviors.withTimers: timer =>
       config.culling match
         case AtlasConfig.Broadcast() =>
@@ -173,7 +173,7 @@ object Atlas:
               )
               for (edgeId, chart) <- charts do chart ! updateRouteTable
 
-              scribe.debug(
+              logger.debug(
                 partitionToSubscriber.toSeq
                   .sortBy((index, _) => (index.x, index.y, index.z))
                   .map((i, senders) =>

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Chart.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Chart.scala
@@ -26,7 +26,11 @@ object Chart:
   trait RouteTable:
     def apply(vector3: Vector3Enu): Map[String, ActorRef[SubscribeBatch]]
 
-  def apply(edgeId: String, initialRouteTable: RouteTable, kamon: CenterKamon): Behavior[Message] =
+  def apply(
+      edgeId: String,
+      initialRouteTable: RouteTable,
+      kamon: CenterKamon
+  ): Behavior[Message] =
     var routeTable = initialRouteTable
     val routeAgentNumCounter = kamon.chartRouteAgentNumCounter(edgeId)
     val routeBatchNumCounter = kamon.chartRouteBatchNumCounter(edgeId)

--- a/arktwin/center/src/main/scala/arktwin/center/actors/ChartRecorder.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/ChartRecorder.scala
@@ -21,7 +21,9 @@ object ChartRecorder:
 
   case class ChartRecord(edgeId: String, indexes: Set[PartitionIndex])
 
-  def apply(edgeId: String): Behavior[Message] =
+  def apply(
+      edgeId: String
+  ): Behavior[Message] =
     // TODO expire agents
     val agents = mutable.Map[String, ChartAgent]()
 

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Clock.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Clock.scala
@@ -8,6 +8,7 @@ import arktwin.center.services.ClockBase
 import arktwin.center.services.ClockBaseExtensions.*
 import arktwin.common.data.TimestampExtensions.*
 import arktwin.common.data.{MachineTag, TaggedDuration, TaggedTimestamp}
+import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -28,7 +29,9 @@ object Clock:
     _
   )
 
-  private def apply(config: ClockConfig): Behavior[Message] = Behaviors.setup: context =>
+  def apply(
+      config: ClockConfig
+  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
     Behaviors.withTimers: initialUpdateSpeedTimer =>
       val baseMachineTimestamp = TaggedTimestamp.machineNow()
       val baseVirtualTimestamp = config.start.initialTime match
@@ -44,9 +47,10 @@ object Clock:
             schedule.secondsDouble.seconds
           )
           ClockBase(baseMachineTimestamp, baseVirtualTimestamp, 0)
-      context.log.info(initialClockBase.toString)
 
       var clockBase = initialClockBase
+      scribe.info(clockBase.toString)
+
       var subscribers = Map[String, ActorRef[ClockBase]]()
       var initialUpdateSpeedTimerFlag = true
 
@@ -62,7 +66,7 @@ object Clock:
             clockSpeed
           )
           for subscriber <- subscribers.values do subscriber ! clockBase
-          context.log.info(clockBase.toString)
+          scribe.info(clockBase.toString)
           Behaviors.same
 
         case AddSubscriber(edgeId, subscriber) =>

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Clock.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Clock.scala
@@ -8,7 +8,7 @@ import arktwin.center.services.ClockBase
 import arktwin.center.services.ClockBaseExtensions.*
 import arktwin.common.data.TimestampExtensions.*
 import arktwin.common.data.{MachineTag, TaggedDuration, TaggedTimestamp}
-import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
+import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -31,7 +31,7 @@ object Clock:
 
   def apply(
       config: ClockConfig
-  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
+  ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
     Behaviors.withTimers: initialUpdateSpeedTimer =>
       val baseMachineTimestamp = TaggedTimestamp.machineNow()
       val baseVirtualTimestamp = config.start.initialTime match
@@ -49,7 +49,7 @@ object Clock:
           ClockBase(baseMachineTimestamp, baseVirtualTimestamp, 0)
 
       var clockBase = initialClockBase
-      scribe.info(clockBase.toString)
+      logger.info(clockBase.toString)
 
       var subscribers = Map[String, ActorRef[ClockBase]]()
       var initialUpdateSpeedTimerFlag = true
@@ -66,7 +66,7 @@ object Clock:
             clockSpeed
           )
           for subscriber <- subscribers.values do subscriber ! clockBase
-          scribe.info(clockBase.toString)
+          logger.info(clockBase.toString)
           Behaviors.same
 
         case AddSubscriber(edgeId, subscriber) =>

--- a/arktwin/center/src/main/scala/arktwin/center/actors/DeadLetterListener.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/DeadLetterListener.scala
@@ -20,7 +20,9 @@ object DeadLetterListener:
     _
   )
 
-  def apply(kamon: CenterKamon): Behavior[Message] = Behaviors.setup: context =>
+  def apply(
+      kamon: CenterKamon
+  ): Behavior[Message] = Behaviors.setup: context =>
     context.system.eventStream ! Subscribe(context.self)
 
     val deadLetterNumCounter = kamon.deadLetterNumCounter()

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Register.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Register.scala
@@ -4,6 +4,7 @@ package arktwin.center.actors
 
 import arktwin.center.services.*
 import arktwin.center.util.CommonMessages.Nop
+import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -39,7 +40,9 @@ object Register:
       temp /= idSuffixCharacters.size
     (if prefix.isEmpty() then "" else prefix + "-") + suffix.toString()
 
-  private def apply(runId: String): Behavior[Message] = Behaviors.setup: context =>
+  def apply(
+      runId: String
+  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
     var edgeNum = 0
     var agentNum = 0
     val agents = mutable.Map[String, RegisterAgent]()
@@ -82,7 +85,7 @@ object Register:
               agents.keys.filter(r.matches)
             catch
               case e: PatternSyntaxException =>
-                context.log.warn(e.getMessage)
+                scribe.warn(e.getMessage)
                 Seq()
           case AgentKindSelector(regex) =>
             try
@@ -90,7 +93,7 @@ object Register:
               agents.filter(a => r.matches(a._2.kind)).keys
             catch
               case e: PatternSyntaxException =>
-                context.log.warn(e.getMessage)
+                scribe.warn(e.getMessage)
                 Seq()
           case _ =>
             Seq()

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Register.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Register.scala
@@ -4,7 +4,7 @@ package arktwin.center.actors
 
 import arktwin.center.services.*
 import arktwin.center.util.CommonMessages.Nop
-import arktwin.common.util.BehaviorsExtensions.setupWithScribeMdc
+import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.MailboxConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
@@ -42,7 +42,7 @@ object Register:
 
   def apply(
       runId: String
-  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
+  ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
     var edgeNum = 0
     var agentNum = 0
     val agents = mutable.Map[String, RegisterAgent]()
@@ -85,7 +85,7 @@ object Register:
               agents.keys.filter(r.matches)
             catch
               case e: PatternSyntaxException =>
-                scribe.warn(e.getMessage)
+                logger.warn(e.getMessage)
                 Seq()
           case AgentKindSelector(regex) =>
             try
@@ -93,7 +93,7 @@ object Register:
               agents.filter(a => r.matches(a._2.kind)).keys
             catch
               case e: PatternSyntaxException =>
-                scribe.warn(e.getMessage)
+                logger.warn(e.getMessage)
                 Seq()
           case _ =>
             Seq()

--- a/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
@@ -4,20 +4,22 @@ package arktwin.center.configs
 
 import arktwin.common.data.{TaggedTimestamp, Vector3Enu}
 import arktwin.common.util.LoggerConfigurator.LogLevel
+import arktwin.common.util.PureConfigHints.given
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.ValidatedNec
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigRenderOptions}
 import pureconfig.*
 import pureconfig.error.ConfigReaderFailures
-import pureconfig.generic.semiauto.deriveReader
-import pureconfig.generic.{FieldCoproductHint, ProductHint}
-
-import scala.concurrent.duration.FiniteDuration
+import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
 
 case class CenterConfig(
     dynamic: DynamicCenterConfig,
     static: StaticCenterConfig
 ) derives ConfigReader:
+  override def toString(): String =
+    given ConfigWriter[CenterConfig] = deriveWriter
+    ConfigWriter[CenterConfig].to(this).render(ConfigRenderOptions.concise())
+
   def validated(path: String): ValidatedNec[String, CenterConfig] =
     import cats.syntax.apply.*
     (
@@ -43,13 +45,6 @@ object CenterConfig:
       )
 
   def loadOrThrow(): CenterConfig =
-    given [A]: ProductHint[A] = ProductHint[A](
-      ConfigFieldMapping(identity),
-      useDefaultArgs = false,
-      allowUnknownKeys = true
-    )
-    given [A]: FieldCoproductHint[A] = new FieldCoproductHint[A]("type"):
-      override def fieldValue(name: String): String = name
     given ConfigReader[CenterConfig] = deriveReader
 
     val path = "arktwin.center"

--- a/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
@@ -16,7 +16,7 @@ case class CenterConfig(
     dynamic: DynamicCenterConfig,
     static: StaticCenterConfig
 ) derives ConfigReader:
-  override def toString(): String =
+  def toJson: String =
     given ConfigWriter[CenterConfig] = deriveWriter
     ConfigWriter[CenterConfig].to(this).render(ConfigRenderOptions.concise())
 

--- a/arktwin/center/src/main/scala/arktwin/center/configs/StaticCenterConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/StaticCenterConfig.scala
@@ -17,6 +17,7 @@ case class StaticCenterConfig(
     portAutoIncrementMax: Int,
     logLevel: LogLevel,
     logLevelColor: Boolean,
+    logSuppressionList: Seq[String],
     actorTimeout: FiniteDuration,
     subscribeBatchSize: Int,
     subscribeBatchInterval: FiniteDuration,
@@ -49,6 +50,7 @@ case class StaticCenterConfig(
       ),
       valid(logLevel),
       valid(logLevelColor),
+      valid(logSuppressionList),
       condNec(
         actorTimeout > 0.second,
         actorTimeout,

--- a/arktwin/center/src/main/scala/arktwin/center/util/CenterReporter.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/util/CenterReporter.scala
@@ -38,7 +38,7 @@ class CenterReporter() extends MetricReporter:
           .mkString("{", ", ", "}")
         val message = s"${metric.name}: ${instrument.value} $tags"
         if metric.name == deadLetterNumName then scribe.warn(message)
-        else scribe.info(message)
+        else scribe.debug(message)
 
     snapshot.histograms
       .filter: metric =>
@@ -59,7 +59,7 @@ class CenterReporter() extends MetricReporter:
           .mkString("{", ", ", "}")
         val summary =
           Seq(0, 25, 50, 75, 100).map(instrument.value.percentile(_).value).mkString(", ")
-        scribe.info(s"${metric.name}: [$summary] ${metric.settings.unit.magnitude.name} $tags")
+        scribe.debug(s"${metric.name}: [$summary] ${metric.settings.unit.magnitude.name} $tags")
 
   override def stop(): Unit = {}
 

--- a/arktwin/common/src/main/scala/arktwin/common/util/ActorLogger.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/ActorLogger.scala
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 TOYOTA MOTOR CORPORATION
+package arktwin.common.util
+
+class ActorLogger(actorPath: String):
+  private val prefix = s"[$actorPath] "
+  def trace(message: => String): Unit = scribe.trace(prefix + message)
+  def debug(message: => String): Unit = scribe.debug(prefix + message)
+  def info(message: => String): Unit = scribe.info(prefix + message)
+  def warn(message: => String): Unit = scribe.warn(prefix + message)
+  def error(message: => String): Unit = scribe.error(prefix + message)
+  def fatal(message: => String): Unit = scribe.fatal(prefix + message)

--- a/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 TOYOTA MOTOR CORPORATION
+package arktwin.common.util
+
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
+import scribe.mdc.MDC
+
+object BehaviorsExtensions:
+  extension (a: Behaviors.type)
+    // use Scribe mdc directly not via Pekko to reduce logging overhead
+    def withScribeMdc[A](behavior: MDC ?=> Behavior[A]): Behavior[A] =
+      MDC: mdc =>
+        Behaviors.setup: context =>
+          mdc("actor") = context.self.path.name
+          behavior(using mdc)
+
+    // use Scribe mdc directly not via Pekko to reduce logging overhead
+    def setupWithScribeMdc[A](factory: MDC ?=> ActorContext[A] => Behavior[A]): Behavior[A] =
+      MDC: mdc =>
+        Behaviors.setup: context =>
+          mdc("actor") = context.self.path.name
+          factory(using mdc)(context)

--- a/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
@@ -7,12 +7,14 @@ import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
 
 object BehaviorsExtensions:
   extension (a: Behaviors.type)
-    // use Scribe wrapper not via Pekko to reduce logging overhead
+    // call Scribe wrapper not via Pekko logger
+    // Pekko logger evaluates unnecessary log messages because of call-by-value strategy
     def withLogger[A](behavior: ActorLogger => Behavior[A]): Behavior[A] =
       Behaviors.setup: context =>
         behavior(ActorLogger(context.self.path.toString))
 
-    // use Scribe wrapper not via Pekko to reduce logging overhead
+    // call Scribe wrapper not via Pekko logger
+    // Pekko logger evaluates unnecessary log messages because of call-by-value strategy
     def setupWithLogger[A](factory: (ActorContext[A], ActorLogger) => Behavior[A]): Behavior[A] =
       Behaviors.setup: context =>
         factory(context, ActorLogger(context.self.path.toString))

--- a/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/BehaviorsExtensions.scala
@@ -10,9 +10,9 @@ object BehaviorsExtensions:
     // use Scribe wrapper not via Pekko to reduce logging overhead
     def withLogger[A](behavior: ActorLogger => Behavior[A]): Behavior[A] =
       Behaviors.setup: context =>
-        behavior(ActorLogger(context.self.path.name))
+        behavior(ActorLogger(context.self.path.toString))
 
     // use Scribe wrapper not via Pekko to reduce logging overhead
     def setupWithLogger[A](factory: (ActorContext[A], ActorLogger) => Behavior[A]): Behavior[A] =
       Behaviors.setup: context =>
-        factory(context, ActorLogger(context.self.path.name))
+        factory(context, ActorLogger(context.self.path.toString))

--- a/arktwin/common/src/main/scala/arktwin/common/util/LoggerConfigurator.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/LoggerConfigurator.scala
@@ -31,8 +31,8 @@ object LoggerConfigurator:
         formatter =
           import scribe.format.*
           if logLevelColor then
-            formatter"$dateFull $coloredLevelPaddedRight $messages   - $logSource $mdc"
-          else formatter"$dateFull $levelPaddedRight $messages   - $logSource $mdc"
+            formatter"$dateFull $coloredLevelPaddedRight $messages   - $logSource"
+          else formatter"$dateFull $levelPaddedRight $messages   - $logSource"
       )
       .replace()
 

--- a/arktwin/common/src/main/scala/arktwin/common/util/LoggerConfigurator.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/LoggerConfigurator.scala
@@ -31,8 +31,8 @@ object LoggerConfigurator:
         formatter =
           import scribe.format.*
           if logLevelColor then
-            formatter"$dateFull $coloredLevelPaddedRight $actor$messages   - $logSource $mdc"
-          else formatter"$dateFull $levelPaddedRight $actor$messages   - $logSource $mdc"
+            formatter"$dateFull $coloredLevelPaddedRight $messages   - $logSource $mdc"
+          else formatter"$dateFull $levelPaddedRight $messages   - $logSource $mdc"
       )
       .replace()
 
@@ -50,9 +50,6 @@ object LoggerConfigurator:
       case Level.Warn  => ColoredOutput(Color.Yellow, output)
       case Level.Error => ColoredOutput(Color.Red, output)
       case _           => output
-
-  private def actor: FormatBlock = FormatBlock: logRecord =>
-    TextOutput(logRecord.data.get("actor").map(a => s"[${a()}] ").getOrElse(""))
 
   private def logSource: FormatBlock = FormatBlock: logRecord =>
     val fileLine = logRecord.fileName + logRecord.line.map(":" + _).getOrElse("")

--- a/arktwin/common/src/main/scala/arktwin/common/util/PureConfigHints.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/PureConfigHints.scala
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 TOYOTA MOTOR CORPORATION
+package arktwin.common.util
+
+import pureconfig.ConfigFieldMapping
+import pureconfig.generic.{FieldCoproductHint, ProductHint}
+
+object PureConfigHints:
+  given productHint[A]: ProductHint[A] = ProductHint[A](
+    ConfigFieldMapping(identity),
+    useDefaultArgs = false,
+    allowUnknownKeys = true
+  )
+  given fieldCoproductHint[A]: FieldCoproductHint[A] = new FieldCoproductHint[A]("type"):
+    override def fieldValue(name: String): String = name

--- a/arktwin/common/src/main/scala/arktwin/common/util/SourceExtensions.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/SourceExtensions.scala
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 TOYOTA MOTOR CORPORATION
+package arktwin.common.util
+
+import org.apache.pekko.stream.scaladsl.{Broadcast, Flow, Sink, Source}
+import scribe.mdc.MDC
+
+import scala.util.{Failure, Success}
+
+object SourceExtensions:
+  extension [Out, Mat](a: Source[Out, Mat])
+    // call Scribe directly not via Pekko stream logger to reduce logging overhead
+    def wireTapLog(streamName: String): Source[Out, Mat] =
+      a.wireTap(
+        Sink.combine(
+          Sink.foreach[Out](a => scribe.trace(s"[$streamName] $a")),
+          Flow[Out]
+            .take(1)
+            .to(Sink.foreach(_ => scribe.info(s"[$streamName] stream receives first element"))),
+          Sink.onComplete[Out]:
+            case Success(done) => scribe.warn(s"[$streamName] upstream completes")
+            case Failure(e)    => scribe.warn(s"[$streamName] downstream cancels, cause: $e")
+        )(Broadcast(_))
+      )

--- a/arktwin/common/src/main/scala/arktwin/common/util/SourceExtensions.scala
+++ b/arktwin/common/src/main/scala/arktwin/common/util/SourceExtensions.scala
@@ -9,7 +9,8 @@ import scala.util.{Failure, Success}
 
 object SourceExtensions:
   extension [Out, Mat](a: Source[Out, Mat])
-    // call Scribe directly not via Pekko stream logger to reduce logging overhead
+    // call Scribe directly not via Pekko logger
+    // Pekko logger evaluates unnecessary log messages because of call-by-value strategy
     def wireTapLog(streamName: String): Source[Out, Mat] =
       a.wireTap(
         Sink.combine(

--- a/arktwin/edge/src/main/resources/pekko.conf
+++ b/arktwin/edge/src/main/resources/pekko.conf
@@ -9,7 +9,6 @@ pekko {
   }
 
   loglevel = info
-  loglevel = ${?ARKTWIN_EDGE_STATIC_LOG_LEVEL}
   log-config-on-start = off
   log-dead-letters = 0
 

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -36,10 +36,13 @@ arktwin {
       portAutoIncrement = ${?ARKTWIN_EDGE_STATIC_PORT_AUTO_INCREMENT}
       portAutoIncrementMax = 100
       portAutoIncrementMax = ${?ARKTWIN_EDGE_STATIC_PORT_AUTO_INCREMENT_MAX}
-      logLevel = info
+      logLevel = Info
       logLevel = ${?ARKTWIN_EDGE_STATIC_LOG_LEVEL}
       logLevelColor = true
       logLevelColor = ${?ARKTWIN_EDGE_STATIC_LOG_LEVEL_COLOR}
+      logSuppressionList = [
+        io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler
+      ]
       actorTimeout = 90ms
       endpointTimeout = 100ms
       clockInitialStashSize = 100

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -42,7 +42,8 @@ arktwin {
       logLevelColor = true
       logLevelColor = ${?ARKTWIN_EDGE_STATIC_LOG_LEVEL_COLOR}
       logSuppressionList = [
-        io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler
+        io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler,
+        "sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter$"
       ]
       actorTimeout = 90ms
       endpointTimeout = 100ms

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -133,7 +133,7 @@ object Edge:
       given Timeout = config.static.actorTimeout
 
       scribe.info(BuildInfo.toString)
-      scribe.info(config.toString)
+      scribe.info(config.toJson)
       val grpcClientConfigPath = "pekko.grpc.client.arktwin"
       scribe.info(s"$grpcClientConfigPath: ${rawConfig.getConfig(grpcClientConfigPath)}")
       scribe.debug(rawConfig.toString)

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -82,7 +82,11 @@ object Edge:
       val config = EdgeConfig.loadOrThrow()
       val rawConfig = EdgeConfig.loadRawOrThrow()
 
-      LoggerConfigurator.init(config.static.logLevel, config.static.logLevelColor)
+      LoggerConfigurator.init(
+        config.static.logLevel,
+        config.static.logLevelColor,
+        config.static.logSuppressionList
+      )
 
       given actorSystem: ActorSystem[SpawnProtocol.Command] = ActorSystem(
         Behaviors.setup[SpawnProtocol.Command](_ => SpawnProtocol()),
@@ -112,7 +116,11 @@ object Edge:
       val config = EdgeConfig.loadOrThrow()
       val rawConfig = EdgeConfig.loadRawOrThrow()
 
-      LoggerConfigurator.init(config.static.logLevel, config.static.logLevelColor)
+      LoggerConfigurator.init(
+        config.static.logLevel,
+        config.static.logLevelColor,
+        config.static.logSuppressionList
+      )
       Kamon.init(rawConfig)
 
       given actorSystem: ActorSystem[SpawnProtocol.Command] = ActorSystem(

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -134,6 +134,8 @@ object Edge:
 
       scribe.info(BuildInfo.toString)
       scribe.info(config.toString)
+      val grpcClientConfigPath = "pekko.grpc.client.arktwin"
+      scribe.info(s"$grpcClientConfigPath: ${rawConfig.getConfig(grpcClientConfigPath)}")
       scribe.debug(rawConfig.toString)
 
       val grpcSettings = GrpcClientSettings.fromConfig("arktwin")

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/DeadLetterListener.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/DeadLetterListener.scala
@@ -20,7 +20,9 @@ object DeadLetterListener:
     _
   )
 
-  def apply(kamon: EdgeKamon): Behavior[Message] = Behaviors.setup: context =>
+  def apply(
+      kamon: EdgeKamon
+  ): Behavior[Message] = Behaviors.setup: context =>
     context.system.eventStream ! Subscribe(context.self)
 
     val deadLetterNumCounter = kamon.deadLetterNumCounter()

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/EdgeConfigurator.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/EdgeConfigurator.scala
@@ -27,7 +27,9 @@ object EdgeConfigurator:
     _
   )
 
-  def apply(initEdgeConfig: EdgeConfig): Behavior[Message] = Behaviors.setup: context =>
+  def apply(
+      initEdgeConfig: EdgeConfig
+  ): Behavior[Message] = Behaviors.setup: context =>
     context.system.receptionist ! Receptionist.subscribe(coordinateObserverKey, context.self)
     context.system.receptionist ! Receptionist.subscribe(cullingObserverKey, context.self)
 

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
@@ -39,7 +39,7 @@ object Chart:
 
   def apply(
       initCullingConfig: CullingConfig
-  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
+  ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
     context.system.receptionist ! Receptionist.Register(
       EdgeConfigurator.cullingObserverKey,
       context.self
@@ -82,7 +82,7 @@ object Chart:
           if newFirstAgents.size <= cullingConfig.maxFirstAgents then firstAgents = newFirstAgents
           else
             if firstAgents.nonEmpty then
-              scribe.warn(
+              logger.warn(
                 "edge culling is disabled because first agents is greater than arktwin.edge.culling.maxFirstAgents"
               )
             firstAgents = Seq()

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
@@ -6,6 +6,7 @@ import arktwin.center.services.ChartAgent
 import arktwin.common.data.TimestampExtensions.*
 import arktwin.common.data.Vector3EnuExtensions.*
 import arktwin.common.data.{TaggedTimestamp, VirtualTag}
+import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.MailboxConfig
 import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.configs.CullingConfig
@@ -38,7 +39,7 @@ object Chart:
 
   def apply(
       initCullingConfig: CullingConfig
-  ): Behavior[Message] = Behaviors.setup: context =>
+  ): Behavior[Message] = Behaviors.setupWithScribeMdc: context =>
     context.system.receptionist ! Receptionist.Register(
       EdgeConfigurator.cullingObserverKey,
       context.self
@@ -81,7 +82,7 @@ object Chart:
           if newFirstAgents.size <= cullingConfig.maxFirstAgents then firstAgents = newFirstAgents
           else
             if firstAgents.nonEmpty then
-              context.log.warn(
+              scribe.warn(
                 "edge culling is disabled because first agents is greater than arktwin.edge.culling.maxFirstAgents"
               )
             firstAgents = Seq()

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Clock.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Clock.scala
@@ -37,14 +37,14 @@ object Clock:
 
   def active(
       initClockBase: ClockBase
-  ): Behavior[Message] = Behaviors.withScribeMdc:
+  ): Behavior[Message] = Behaviors.withLogger: logger =>
     var clockBase = initClockBase
-    scribe.info(clockBase.toString)
+    logger.info(clockBase.toString)
 
     Behaviors.receiveMessage:
       case Catch(newClockBase) =>
         clockBase = newClockBase
-        scribe.info(clockBase.toString)
+        logger.info(clockBase.toString)
         Behaviors.same
 
       case Get(replyTo) =>

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
@@ -3,13 +3,13 @@
 package arktwin.edge.configs
 
 import arktwin.common.util.LoggerConfigurator.LogLevel
+import arktwin.common.util.PureConfigHints.given
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.ValidatedNec
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigRenderOptions}
 import pureconfig.*
 import pureconfig.error.ConfigReaderFailures
-import pureconfig.generic.semiauto.deriveReader
-import pureconfig.generic.{FieldCoproductHint, ProductHint}
+import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -17,6 +17,10 @@ case class EdgeConfig(
     dynamic: DynamicEdgeConfig,
     static: StaticEdgeConfig
 ) derives ConfigReader:
+  override def toString(): String =
+    given ConfigWriter[EdgeConfig] = deriveWriter
+    ConfigWriter[EdgeConfig].to(this).render(ConfigRenderOptions.concise())
+
   def validated(path: String): ValidatedNec[String, EdgeConfig] =
     import cats.syntax.apply.*
     (
@@ -42,13 +46,6 @@ object EdgeConfig:
       )
 
   def loadOrThrow(): EdgeConfig =
-    given [A]: ProductHint[A] = ProductHint[A](
-      ConfigFieldMapping(identity),
-      useDefaultArgs = false,
-      allowUnknownKeys = true
-    )
-    given [A]: FieldCoproductHint[A] = new FieldCoproductHint[A]("type"):
-      override def fieldValue(name: String): String = name
     given ConfigReader[EdgeConfig] = deriveReader
 
     val path = "arktwin.edge"

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
@@ -17,7 +17,7 @@ case class EdgeConfig(
     dynamic: DynamicEdgeConfig,
     static: StaticEdgeConfig
 ) derives ConfigReader:
-  override def toString(): String =
+  def toJson: String =
     given ConfigWriter[EdgeConfig] = deriveWriter
     ConfigWriter[EdgeConfig].to(this).render(ConfigRenderOptions.concise())
 

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/RotationConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/RotationConfig.scala
@@ -26,7 +26,7 @@ case class EulerAnglesConfig(
     @description("angle unit")
     angleUnit: EulerAnglesConfig.AngleUnit,
     @description(
-      "rotation mode: extrinsic rotation (world space rotation) or intrinsic rotation (agent space rotation)"
+      "rotation mode: extrinsic rotation (world space rotation) or intrinsic rotation (agent's local space rotation)"
     )
     rotationMode: EulerAnglesConfig.RotationMode,
     @description(

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/StaticEdgeConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/StaticEdgeConfig.scala
@@ -18,6 +18,7 @@ case class StaticEdgeConfig(
     portAutoIncrementMax: Int,
     logLevel: LogLevel,
     logLevelColor: Boolean,
+    logSuppressionList: Seq[String],
     actorTimeout: FiniteDuration,
     endpointTimeout: FiniteDuration,
     clockInitialStashSize: Int,
@@ -53,6 +54,7 @@ case class StaticEdgeConfig(
       ),
       valid(logLevel),
       valid(logLevelColor),
+      valid(logSuppressionList),
       condNec(
         actorTimeout > 0.second,
         actorTimeout,

--- a/arktwin/edge/src/main/scala/arktwin/edge/connectors/ChartConnector.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/connectors/ChartConnector.scala
@@ -6,6 +6,7 @@ import arktwin.center.services.{ChartAgent, ChartClient, ChartPublishBatch}
 import arktwin.common.data.TimestampExtensions.*
 import arktwin.common.data.{MachineTimestamp, TaggedTimestamp}
 import arktwin.common.util.GrpcHeaderKey
+import arktwin.common.util.SourceExtensions.*
 import arktwin.edge.actors.sinks.Chart
 import arktwin.edge.configs.StaticEdgeConfig
 import arktwin.edge.util.CommonMessages.Nop
@@ -55,6 +56,7 @@ case class ChartConnector(
           a.agents.size
         )
         batches
+      .wireTapLog("Chart.Publish")
       .preMaterialize()
     client
       .publish()
@@ -72,7 +74,7 @@ case class ChartConnector(
       .subscribe()
       .addHeader(GrpcHeaderKey.edgeId, edgeId)
       .invoke(Empty())
-      .log(getClass.getSimpleName + ".subscribe")
+      .wireTapLog("Chart.Subscribe")
       .mapConcat: a =>
         val currentMachineTimestamp = TaggedTimestamp.machineNow()
         subscribeAgentNumCounter.increment(a.agents.size)

--- a/arktwin/edge/src/main/scala/arktwin/edge/connectors/ClockConnector.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/connectors/ClockConnector.scala
@@ -4,6 +4,7 @@ package arktwin.edge.connectors
 
 import arktwin.center.services.ClockClient
 import arktwin.common.util.GrpcHeaderKey
+import arktwin.common.util.SourceExtensions.*
 import arktwin.edge.actors.sinks.Clock
 import arktwin.edge.util.CommonMessages.Nop
 import com.google.protobuf.empty.Empty
@@ -18,7 +19,7 @@ case class ClockConnector(client: ClockClient, edgeId: String)(using Materialize
       .subscribe()
       .addHeader(GrpcHeaderKey.edgeId, edgeId)
       .invoke(Empty())
-      .log(getClass.getSimpleName + ".subscribe")
+      .wireTapLog("Clock.Subscribe")
       .map(Clock.Catch.apply)
       .to(ActorSink.actorRef(clock, Nop, _ => Nop))
       .run()

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/CenterAgentsDelete.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/CenterAgentsDelete.scala
@@ -5,6 +5,7 @@ package arktwin.edge.endpoints
 import arktwin.center.services.*
 import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampEx.*
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus, JsonDerivation, JsonValidator, RequestValidator}
 import cats.implicits.toTraverseOps
@@ -51,7 +52,7 @@ object CenterAgentsDelete:
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: request =>
+      endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()
         RequestValidator(request.asMessage)
           .map(client.deleteAgents(_).map(_ => {}))

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/CenterClockSpeedPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/CenterClockSpeedPut.scala
@@ -5,6 +5,7 @@ package arktwin.edge.endpoints
 import arktwin.center.services.{AdminClient, UpdateClockSpeedRequest}
 import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampEx.*
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus, RequestValidator}
 import cats.implicits.toTraverseOps
@@ -46,7 +47,7 @@ object CenterClockSpeedPut:
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: request =>
+      endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()
         RequestValidator(request)
           .map(client.updateClockSpeed(_).map(_ => {}))

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPost.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPost.scala
@@ -6,6 +6,7 @@ import arktwin.center.services
 import arktwin.center.services.{CreateAgentRequest, CreateAgentResponse, RegisterClient}
 import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampEx.*
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus, RequestValidator}
 import cats.implicits.toTraverseOps
@@ -65,7 +66,7 @@ object EdgeAgentsPost:
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: requests =>
+      endpoint.serverLogicWithLog: requests =>
         val requestTime = TaggedTimestamp.machineNow()
         RequestValidator(services.CreateAgentsRequest(requests))
           .map(client.createAgents)

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
@@ -7,6 +7,7 @@ import arktwin.common.data.{TaggedTimestamp, VirtualTimestamp}
 import arktwin.edge.actors.adapters.EdgeAgentsPutAdapter
 import arktwin.edge.configs.StaticEdgeConfig
 import arktwin.edge.data.*
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
@@ -106,7 +107,7 @@ object EdgeAgentsPut:
 
     given Timeout = staticConfig.endpointTimeout
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: request =>
+      endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()
         adapter
           .?[Either[ErrorStatus, Response]](

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCullingPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCullingPut.scala
@@ -6,6 +6,7 @@ import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampEx.*
 import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.configs.CullingConfig
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{BadRequest, EdgeKamon, ErrorStatus}
 import cats.data.Validated.{Invalid, Valid}
@@ -48,14 +49,14 @@ object EdgeConfigCullingPut:
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: request =>
+      endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()
         (request.validated("") match
           case Invalid(errors) =>
             Future.successful(Left(BadRequest(errors.toChain.toVector)))
           case Valid(request) =>
             configurator ! request
-            Future.successful(Right(()): Either[ErrorStatus, Response])
+            Future.successful(Right[ErrorStatus, Response](()))
         ).andThen: _ =>
           requestNumCounter.increment()
           processMachineTimeHistogram.record(TaggedTimestamp.machineNow() - requestTime)

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -43,6 +43,7 @@ object EdgeConfigGet:
       portAutoIncrementMax = 100,
       logLevel = LogLevel.Info,
       logLevelColor = true,
+      logSuppressionList = Seq(),
       actorTimeout = 90.milliseconds,
       endpointTimeout = 100.milliseconds,
       clockInitialStashSize = 100,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -7,6 +7,7 @@ import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampEx.*
 import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.configs.{DynamicEdgeConfig, EdgeConfig, StaticEdgeConfig}
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
@@ -73,7 +74,7 @@ object EdgeConfigGet:
 
     given Timeout = staticConfig.endpointTimeout
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: _ =>
+      endpoint.serverLogicWithLog: _ =>
         val requestTime = TaggedTimestamp.machineNow()
         (configurator ? EdgeConfigurator.Get.apply)
           .map(Right[ErrorStatus, EdgeConfig].apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
@@ -7,6 +7,7 @@ import arktwin.common.data.{TaggedTimestamp, VirtualTimestamp}
 import arktwin.edge.actors.adapters.EdgeNeighborsQueryAdapter
 import arktwin.edge.configs.StaticEdgeConfig
 import arktwin.edge.data.*
+import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.JsonDerivation.given
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
@@ -92,7 +93,7 @@ object EdgeNeighborsQuery:
 
     given Timeout = staticConfig.endpointTimeout
     PekkoHttpServerInterpreter().toRoute:
-      endpoint.serverLogic: request =>
+      endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()
         adapter
           .?[Either[ErrorStatus, Response]](EdgeNeighborsQueryAdapter.Query(request, _))

--- a/arktwin/edge/src/main/scala/arktwin/edge/util/EdgeReporter.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/util/EdgeReporter.scala
@@ -38,7 +38,7 @@ class EdgeReporter() extends MetricReporter:
           .mkString("{", ", ", "}")
         val message = s"${metric.name}: ${instrument.value} $tags"
         if metric.name == deadLetterNumName then scribe.warn(message)
-        else scribe.info(message)
+        else scribe.debug(message)
 
     snapshot.histograms
       .filter: metric =>
@@ -60,7 +60,7 @@ class EdgeReporter() extends MetricReporter:
           .mkString("{", ", ", "}")
         val summary =
           Seq(0, 25, 50, 75, 100).map(instrument.value.percentile(_).value).mkString(", ")
-        scribe.info(s"${metric.name}: [$summary] ${metric.settings.unit.magnitude.name} $tags")
+        scribe.debug(s"${metric.name}: [$summary] ${metric.settings.unit.magnitude.name} $tags")
 
   override def stop(): Unit = {}
 

--- a/arktwin/edge/src/main/scala/arktwin/edge/util/EndpointExtensions.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/util/EndpointExtensions.scala
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 TOYOTA MOTOR CORPORATION
+package arktwin.edge.util;
+
+import sttp.tapir.PublicEndpoint
+import sttp.tapir.server.ServerEndpoint
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+object EndpointExtensions:
+  extension [Input, Output](endpoint: PublicEndpoint[Input, ErrorStatus, Output, Any])
+    def serverLogicWithLog(
+        f: Input => Future[Either[ErrorStatus, Output]]
+    )(using
+        ExecutionContext
+    ): ServerEndpoint.Full[Unit, Unit, Input, ErrorStatus, Output, Any, Future] =
+      endpoint.serverLogic: request =>
+        scribe.trace(s"[${endpoint.showShort}] Request: $request")
+        f(request).andThen:
+          case Success(Right(response)) =>
+            scribe.trace(s"[${endpoint.showShort}] Response: $response")
+          case Success(Left(errorStatus)) =>
+            scribe.warn(s"[${endpoint.showShort}] Response: $errorStatus")
+          case Failure(throwable) =>
+            scribe.warn(s"[${endpoint.showShort}] Error: $throwable")


### PR DESCRIPTION
- All logging within ArkTwin call Scribe not via Pekko logger
  - Pekko logger evaluates unnecessary log messages because of call-by-value strategy
- Add either the actor address, stream name, or endpoint name as a prefix to the log message
- The environment variable `ARKTWIN_EDGE_STATIC_LOG_LEVEL` will no longer affect setting pekko.loglevel
- Add config `arktwin.{center, edge}.static.logSuppressionList`
- Add many trace logs
- Change metrics log level to debug