### PR TITLE
Decouple unit tests from OpenAPI examples

### DIFF
--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCoordinatePut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCoordinatePut.scala
@@ -34,19 +34,19 @@ object EdgeConfigCoordinatePut:
   given JsonValueCodec[Request] = JsonDerivation.makeCodec
 
   val inExample: Request = Request(
-    AxisConfig(
-      Direction.East,
-      Direction.North,
-      Direction.Up
+    axis = AxisConfig(
+      xDirection = Direction.East,
+      yDirection = Direction.North,
+      zDirection = Direction.Up
     ),
-    Vector3(0, 0, 0),
-    EulerAnglesConfig(
-      AngleUnit.Degree,
-      RotationMode.Extrinsic,
-      RotationOrder.XYZ
+    centerOrigin = Vector3(0, 0, 0),
+    rotation = EulerAnglesConfig(
+      angleUnit = AngleUnit.Degree,
+      rotationMode = RotationMode.Extrinsic,
+      rotationOrder = RotationOrder.XYZ
     ),
-    LengthUnit.Meter,
-    SpeedUnit.MeterPerSecond
+    lengthUnit = LengthUnit.Meter,
+    speedUnit = SpeedUnit.MeterPerSecond
   )
 
   val endpoint: PublicEndpoint[Request, ErrorStatus, Response, Any] =

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCullingPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigCullingPut.scala
@@ -29,7 +29,10 @@ object EdgeConfigCullingPut:
   val Request: CullingConfig.type = CullingConfig
   given JsonValueCodec[Request] = JsonDerivation.makeCodec
 
-  val inExample: Request = Request(edgeCulling = true, 9)
+  val inExample: Request = Request(
+    edgeCulling = true,
+    maxFirstAgents = 9
+  )
 
   val endpoint: PublicEndpoint[Request, ErrorStatus, Response, Any] =
     tapir.endpoint.put

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -2,71 +2,111 @@
 // Copyright 2024-2025 TOYOTA MOTOR CORPORATION
 package arktwin.edge.actors
 
+import arktwin.common.util.LoggerConfigurator.LogLevel
 import arktwin.edge.actors.EdgeConfigurator.*
-import arktwin.edge.configs.{EdgeConfig, QuaternionConfig}
-import arktwin.edge.endpoints.EdgeConfigGet
+import arktwin.edge.configs.*
+import arktwin.edge.configs.AxisConfig.Direction
+import arktwin.edge.configs.CoordinateConfig.{LengthUnit, SpeedUnit}
+import arktwin.edge.configs.EulerAnglesConfig.{AngleUnit, RotationMode, RotationOrder}
+import arktwin.edge.data.Vector3
 import arktwin.edge.test.ActorTestBase
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.apache.pekko.actor.typed.receptionist.Receptionist
 
+import scala.concurrent.duration.DurationInt
 import scala.util.Using
 
 class EdgeConfiguratorSpec extends ActorTestBase:
+  private val baseConfig = EdgeConfig(
+    dynamic = DynamicEdgeConfig(
+      coordinate = CoordinateConfig(
+        axis = AxisConfig(
+          xDirection = Direction.East,
+          yDirection = Direction.North,
+          zDirection = Direction.Up
+        ),
+        centerOrigin = Vector3(0, 0, 0),
+        rotation = EulerAnglesConfig(
+          angleUnit = AngleUnit.Degree,
+          rotationMode = RotationMode.Extrinsic,
+          rotationOrder = RotationOrder.XYZ
+        ),
+        lengthUnit = LengthUnit.Meter,
+        speedUnit = SpeedUnit.MeterPerSecond
+      ),
+      culling = CullingConfig(
+        edgeCulling = true,
+        maxFirstAgents = 9
+      )
+    ),
+    static = StaticEdgeConfig(
+      edgeIdPrefix = "edge",
+      host = "0.0.0.0",
+      port = 2237,
+      portAutoIncrement = true,
+      portAutoIncrementMax = 100,
+      logLevel = LogLevel.Info,
+      logLevelColor = true,
+      logSuppressionList = Seq(),
+      actorTimeout = 90.milliseconds,
+      endpointTimeout = 100.milliseconds,
+      clockInitialStashSize = 100,
+      publishBatchSize = 100,
+      publishBufferSize = 10000
+    )
+  )
+
   describe("EdgeConfigurator"):
     describe("Read"):
       it("replies current edge configuration"):
         Using(ActorTestKit()): testKit =>
-          val config = EdgeConfigGet.outExample
-          val configurator = testKit.spawn(EdgeConfigurator(config))
+          val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
 
           configurator ! Read(reader.ref)
 
-          assert(reader.receiveMessage() == config)
+          assert(reader.receiveMessage() == baseConfig)
 
       it("replies updated configuration after coordinate config update"):
         Using(ActorTestKit()): testKit =>
-          val config = EdgeConfigGet.outExample
-          val configurator = testKit.spawn(EdgeConfigurator(config))
+          val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
-          val newCoordinateConfig = config.dynamic.coordinate.copy(rotation = QuaternionConfig)
+          val newCoordinateConfig = baseConfig.dynamic.coordinate.copy(rotation = QuaternionConfig)
 
           configurator ! UpdateCoordinateConfig(newCoordinateConfig)
           configurator ! Read(reader.ref)
 
           val receivedConfig = reader.receiveMessage()
           assert(receivedConfig.dynamic.coordinate == newCoordinateConfig)
-          assert(receivedConfig.dynamic.culling == config.dynamic.culling)
+          assert(receivedConfig.dynamic.culling == baseConfig.dynamic.culling)
 
       it("replies updated configuration after culling config update"):
         Using(ActorTestKit()): testKit =>
-          val config = EdgeConfigGet.outExample
-          val configurator = testKit.spawn(EdgeConfigurator(config))
+          val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
-          val newCullingConfig = config.dynamic.culling.copy(maxFirstAgents = 999)
+          val newCullingConfig = baseConfig.dynamic.culling.copy(maxFirstAgents = 999)
 
           configurator ! UpdateCullingConfig(newCullingConfig)
           configurator ! Read(reader.ref)
 
           val receivedConfig = reader.receiveMessage()
-          assert(receivedConfig.dynamic.coordinate == config.dynamic.coordinate)
+          assert(receivedConfig.dynamic.coordinate == baseConfig.dynamic.coordinate)
           assert(receivedConfig.dynamic.culling == newCullingConfig)
 
     describe("UpdateCoordinateConfig"):
       it("distributes coordinate configuration to registered coordinate observers"):
         Using(ActorTestKit()): testKit =>
-          val config = EdgeConfigGet.outExample
-          val configurator = testKit.spawn(EdgeConfigurator(config))
+          val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val observer1 = testKit.createTestProbe[UpdateCoordinateConfig]()
           val observer2 = testKit.createTestProbe[UpdateCoordinateConfig]()
 
           testKit.system.receptionist ! Receptionist.register(coordinateObserverKey, observer1.ref)
           testKit.system.receptionist ! Receptionist.register(coordinateObserverKey, observer2.ref)
 
-          assert(observer1.receiveMessage().config == config.dynamic.coordinate)
-          assert(observer2.receiveMessage().config == config.dynamic.coordinate)
+          assert(observer1.receiveMessage().config == baseConfig.dynamic.coordinate)
+          assert(observer2.receiveMessage().config == baseConfig.dynamic.coordinate)
 
-          val newConfig = config.dynamic.coordinate.copy(rotation = QuaternionConfig)
+          val newConfig = baseConfig.dynamic.coordinate.copy(rotation = QuaternionConfig)
           configurator ! UpdateCoordinateConfig(newConfig)
 
           assert(observer1.receiveMessage().config == newConfig)
@@ -75,18 +115,17 @@ class EdgeConfiguratorSpec extends ActorTestBase:
     describe("UpdateCullingConfig"):
       it("distributes culling configuration to registered culling observers"):
         Using(ActorTestKit()): testKit =>
-          val config = EdgeConfigGet.outExample
-          val configurator = testKit.spawn(EdgeConfigurator(config))
+          val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val observer1 = testKit.createTestProbe[UpdateCullingConfig]()
           val observer2 = testKit.createTestProbe[UpdateCullingConfig]()
 
           testKit.system.receptionist ! Receptionist.register(cullingObserverKey, observer1.ref)
           testKit.system.receptionist ! Receptionist.register(cullingObserverKey, observer2.ref)
 
-          assert(observer1.receiveMessage() == UpdateCullingConfig(config.dynamic.culling))
-          assert(observer2.receiveMessage() == UpdateCullingConfig(config.dynamic.culling))
+          assert(observer1.receiveMessage() == UpdateCullingConfig(baseConfig.dynamic.culling))
+          assert(observer2.receiveMessage() == UpdateCullingConfig(baseConfig.dynamic.culling))
 
-          val newConfig = config.dynamic.culling.copy(maxFirstAgents = 456)
+          val newConfig = baseConfig.dynamic.culling.copy(maxFirstAgents = 456)
           configurator ! UpdateCullingConfig(newConfig)
 
           assert(observer1.receiveMessage() == UpdateCullingConfig(newConfig))

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
@@ -11,15 +11,33 @@ import arktwin.edge.test.ActorTestBase
 import org.scalactic.{Equality, TolerantNumerics}
 
 class ChartSpec extends ActorTestBase:
-  given Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.001)
+  private given Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.001)
 
-  given Equality[Option[Double]] =
+  private given Equality[Option[Double]] =
     case (Some(a), Some(b)) =>
       summon[Equality[Double]].areEqual(a, b)
     case (None, None) =>
       true
     case _ =>
       false
+
+  private def chartAgent(
+      agentId: String,
+      timestamp: Timestamp,
+      translation: Vector3Enu
+  ): ChartAgent =
+    ChartAgent(
+      agentId,
+      TransformEnu(
+        timestamp,
+        None,
+        Vector3Enu(0, 0, 0),
+        QuaternionEnu(0, 0, 0, 0),
+        translation,
+        Vector3Enu(0, 0, 0),
+        Map()
+      )
+    )
 
   describe("Chart"):
     describe("Read"):
@@ -241,21 +259,3 @@ class ChartSpec extends ActorTestBase:
             )
           )
         }
-
-  private def chartAgent(
-      agentId: String,
-      timestamp: Timestamp,
-      translation: Vector3Enu
-  ): ChartAgent =
-    ChartAgent(
-      agentId,
-      TransformEnu(
-        timestamp,
-        None,
-        Vector3Enu(0, 0, 0),
-        QuaternionEnu(0, 0, 0, 0),
-        translation,
-        Vector3Enu(0, 0, 0),
-        Map()
-      )
-    )


### PR DESCRIPTION
Unit tests now define their own test data instead of relying on OpenAPI input/output examples.
This prevents test breakage when examples are modified for better user documentation.