### PR TITLE
 Rename configuration fields and metrics to explicitly indicate machine time

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Some configuration can be overridden using environment variables.
   - arktwin_center_chart_2_publish_from_edge_machine_latency {edge_id, run_id}
   - arktwin_center_chart_3_route_agent_num {edge_id, run_id}
   - arktwin_center_chart_3_route_batch_num {edge_id, run_id}
-  - arktwin_center_chart_3_route_machine_from_publish_machine_latency {edge_id, run_id}
+  - arktwin_center_chart_3_route_from_publish_machine_latency {edge_id, run_id}
   - arktwin_center_chart_4_subscribe_agent_num {edge_id, run_id}
   - arktwin_center_chart_4_subscribe_batch_num {edge_id, run_id}
   - arktwin_center_chart_4_subscribe_from_route_machine_latency {edge_id, run_id}
@@ -231,7 +231,7 @@ Some configuration can be overridden using environment variables.
   - arktwin_edge_rest_agent_num {endpoint, edge_id, run_id}
   - arktwin_edge_rest_request_num {endpoint, edge_id, run_id}
   - arktwin_edge_rest_process_machine_time {endpoint, edge_id, run_id}
-  - arktwin_edge_rest_virtual_latency {endpoint, edge_id, run_id}
+  - arktwin_edge_rest_latency {endpoint, edge_id, run_id}
 - Other metrics
   - arktwin_center_dead_letter_num {recipient, edge_id, run_id}
   - arktwin_edge_dead_letter_num {recipient, edge_id, run_id}

--- a/arktwin/center/src/main/resources/reference.conf
+++ b/arktwin/center/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ arktwin {
             z = 10
           }
         }
-        routeTableUpdateInterval = 1s
+        routeTableUpdateMachineInterval = 1s
       }
     }
     static {
@@ -30,7 +30,6 @@ arktwin {
               seconds = 0
               nanos = 0
             }
-            agentsCheckInterval = 100ms
           }
         }
       }
@@ -49,9 +48,9 @@ arktwin {
       logLevelColor = true
       logLevelColor = ${?ARKTWIN_CENTER_STATIC_LOG_LEVEL_COLOR}
       logSuppressionList = []
-      actorTimeout = 10s
+      actorMachineTimeout = 10s
       subscribeBatchSize = 100
-      subscribeBatchInterval = 10ms
+      subscribeBatchMachineInterval = 10ms
       subscribeBufferSize = 10000
     }
   }

--- a/arktwin/center/src/main/scala/arktwin/center/Center.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/Center.scala
@@ -42,7 +42,7 @@ object Center:
     )
     given ExecutionContextExecutor = actorSystem.executionContext
     given Scheduler = actorSystem.scheduler
-    given Timeout = config.static.actorTimeout
+    given Timeout = config.static.actorMachineTimeout
 
     scribe.info(BuildInfo.toString)
     scribe.info(config.toJson)

--- a/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/actors/Atlas.scala
@@ -50,7 +50,7 @@ object Atlas:
       kamon: CenterKamon
   ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
     Behaviors.withTimers: timer =>
-      timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateInterval)
+      timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateMachineInterval)
 
       var chartRecorders = Map[String, ActorRef[ChartRecorder.Message]]()
       var charts = Map[String, ActorRef[Chart.Message]]()
@@ -100,7 +100,7 @@ object Atlas:
           Behaviors.same
 
         case UpdateRouteTableTerminated =>
-          timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateInterval)
+          timer.startSingleTimer(SpawnUpdateRouteTable, config.routeTableUpdateMachineInterval)
           Behaviors.same
 
         case SpawnUpdateRouteTable =>
@@ -129,7 +129,7 @@ object Atlas:
           Behaviors.stopped
 
         case AtlasConfig.GridCulling(gridCellSize) =>
-          timer.startSingleTimer(Timeout, config.routeTableUpdateInterval)
+          timer.startSingleTimer(Timeout, config.routeTableUpdateMachineInterval)
 
           for (_, chartRecorder) <- chartRecorders do
             chartRecorder ! ChartRecorder.Get(config, context.self)

--- a/arktwin/center/src/main/scala/arktwin/center/configs/AtlasConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/AtlasConfig.scala
@@ -10,16 +10,16 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 case class AtlasConfig(
     culling: AtlasConfig.Culling,
-    routeTableUpdateInterval: FiniteDuration
+    routeTableUpdateMachineInterval: FiniteDuration
 ):
   def validated(path: String): ValidatedNec[String, AtlasConfig] =
     import cats.syntax.apply.*
     (
       culling.validated(s"$path.culling"),
       condNec(
-        routeTableUpdateInterval > 0.second,
-        routeTableUpdateInterval,
-        s"$path.routeTableUpdateInterval must be > 0"
+        routeTableUpdateMachineInterval > 0.second,
+        routeTableUpdateMachineInterval,
+        s"$path.routeTableUpdateMachineInterval must be > 0"
       )
     ).mapN(AtlasConfig.apply)
 

--- a/arktwin/center/src/main/scala/arktwin/center/configs/StaticCenterConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/StaticCenterConfig.scala
@@ -18,9 +18,9 @@ case class StaticCenterConfig(
     logLevel: LogLevel,
     logLevelColor: Boolean,
     logSuppressionList: Seq[String],
-    actorTimeout: FiniteDuration,
+    actorMachineTimeout: FiniteDuration,
     subscribeBatchSize: Int,
-    subscribeBatchInterval: FiniteDuration,
+    subscribeBatchMachineInterval: FiniteDuration,
     subscribeBufferSize: Int
 ):
   def validated(path: String): ValidatedNec[String, StaticCenterConfig] =
@@ -52,9 +52,9 @@ case class StaticCenterConfig(
       valid(logLevelColor),
       valid(logSuppressionList),
       condNec(
-        actorTimeout > 0.second,
-        actorTimeout,
-        s"$path.actorTimeout must be > 0"
+        actorMachineTimeout > 0.second,
+        actorMachineTimeout,
+        s"$path.actorMachineTimeout must be > 0"
       ),
       condNec(
         subscribeBatchSize > 0,
@@ -62,9 +62,9 @@ case class StaticCenterConfig(
         s"$path.subscribeBatchSize must be > 0"
       ),
       condNec(
-        subscribeBatchInterval > 0.second,
-        subscribeBatchInterval,
-        s"$path.subscribeBatchInterval must be > 0"
+        subscribeBatchMachineInterval > 0.second,
+        subscribeBatchMachineInterval,
+        s"$path.subscribeBatchMachineInterval must be > 0"
       ),
       condNec(
         subscribeBufferSize > 0,

--- a/arktwin/center/src/main/scala/arktwin/center/services/ChartService.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/services/ChartService.scala
@@ -83,7 +83,7 @@ class ChartService(
         config.subscribeBufferSize,
         OverflowStrategy.dropHead
       )
-      .groupedWeightedWithin(config.subscribeBatchSize, config.subscribeBatchInterval)(
+      .groupedWeightedWithin(config.subscribeBatchSize, config.subscribeBatchMachineInterval)(
         _.agents.size
       )
       .map: subscribeBatch =>

--- a/arktwin/center/src/main/scala/arktwin/center/util/CenterKamon.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/util/CenterKamon.scala
@@ -64,7 +64,7 @@ object CenterKamon:
   inline val chartRouteAgentNumName = "arktwin_center_chart_3_route_agent_num"
   inline val chartRouteBatchNumName = "arktwin_center_chart_3_route_batch_num"
   inline val chartRouteMachineLatencyName =
-    "arktwin_center_chart_3_route_machine_from_publish_machine_latency"
+    "arktwin_center_chart_3_route_from_publish_machine_latency"
   inline val chartSubscribeAgentNumName = "arktwin_center_chart_4_subscribe_agent_num"
   inline val chartSubscribeBatchNumName = "arktwin_center_chart_4_subscribe_batch_num"
   inline val chartSubscribeMachineLatencyName =

--- a/arktwin/center/src/test/scala/arktwin/center/actors/AtlasSpec.scala
+++ b/arktwin/center/src/test/scala/arktwin/center/actors/AtlasSpec.scala
@@ -27,7 +27,7 @@ class AtlasSpec extends ActorTestBase:
       val atlas = testKit.spawn(Atlas(atlasConfig, CenterKamon("")))
 
       val (publisherA, subscriberA) = createPubSub("A", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val a1 = chartAgent("a1", Timestamp(0, 0), Vector3Enu(1, 2, 3))
       val a2 = chartAgent("a2", Timestamp(0, 0), Vector3Enu(1, 2, 3))
@@ -35,7 +35,7 @@ class AtlasSpec extends ActorTestBase:
       subscriberA.expectNoMessage()
 
       val (publisherB, subscriberB) = createPubSub("B", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val b1 = chartAgent("b1", Timestamp(0, 0), Vector3Enu(1, 2, 3))
       val b2 = chartAgent("b2", Timestamp(0, 0), Vector3Enu(1, 2, 3))
@@ -48,7 +48,7 @@ class AtlasSpec extends ActorTestBase:
       subscriberB.expectNoMessage()
 
       val (publisherC, subscriberC) = createPubSub("C", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val c1 = chartAgent("c1", Timestamp(0, 0), Vector3Enu(1, 2, 3))
       val c2 = chartAgent("c2", Timestamp(0, 0), Vector3Enu(1, 2, 3))
@@ -79,7 +79,7 @@ class AtlasSpec extends ActorTestBase:
 
       publisherB ! Terminate
       subscriberB.stop()
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       publisherA ! Chart.PublishBatch(Seq(a1, a2), MachineTimestamp(0, 0))
       publisherB ! Chart.PublishBatch(Seq(b1, b2), MachineTimestamp(0, 0))
@@ -95,7 +95,7 @@ class AtlasSpec extends ActorTestBase:
       val atlas = testKit.spawn(Atlas(atlasConfig, CenterKamon("")))
 
       val (publisherA, subscriberA) = createPubSub("A", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val a1_0 = chartAgent("a1", Timestamp(0, 0), Vector3Enu(1, 1, 1)) // [0, 0, 0]
       val a2_0 = chartAgent("a2", Timestamp(0, 0), Vector3Enu(1, 1, 1)) // [0, 0, 0]
@@ -103,7 +103,7 @@ class AtlasSpec extends ActorTestBase:
       subscriberA.expectNoMessage()
 
       val (publisherB, subscriberB) = createPubSub("B", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val b1_0 = chartAgent("b1", Timestamp(0, 0), Vector3Enu(1, 1, 1)) // [0, 0, 0]
       val b2_0 = chartAgent("b2", Timestamp(0, 0), Vector3Enu(21, 1, 1)) // [2, 0, 0]
@@ -113,7 +113,7 @@ class AtlasSpec extends ActorTestBase:
       subscriberB.expectNoMessage()
 
       val (publisherC, subscriberC) = createPubSub("C", atlas)
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val c1_0 = chartAgent("c1", Timestamp(0, 0), Vector3Enu(11, 1, 1)) // [1, 0, 0]
       val c2_0 = chartAgent("c2", Timestamp(0, 0), Vector3Enu(31, 1, 1001)) // [3, 0, 1]
@@ -124,7 +124,7 @@ class AtlasSpec extends ActorTestBase:
       subscriberB.expectNoMessage()
       subscriberC.expectNoMessage()
 
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       val a1_1 = chartAgent("a1", Timestamp(1, 0), Vector3Enu(41, 101, 1001)) // [4, 1, 1]
       val a2_1 = chartAgent("a2", Timestamp(1, 0), Vector3Enu(41, 201, -1)) // [4, 2, -1]
@@ -136,7 +136,7 @@ class AtlasSpec extends ActorTestBase:
 
       publisherB ! Terminate
       subscriberB.stop()
-      Thread.sleep(atlasConfig.routeTableUpdateInterval.toMillis * 2)
+      Thread.sleep(atlasConfig.routeTableUpdateMachineInterval.toMillis * 2)
 
       publisherC ! Chart.PublishBatch(Seq(c1_0, c2_0), MachineTimestamp(0, 0))
       assert(subscriberA.receiveMessage().agents.sorted == Seq(c2_0))

--- a/arktwin/center/src/test/scala/arktwin/center/configs/CenterConfigSpec.scala
+++ b/arktwin/center/src/test/scala/arktwin/center/configs/CenterConfigSpec.scala
@@ -17,7 +17,7 @@ class CenterConfigSpec extends AnyFunSpec:
           dynamic = DynamicCenterConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.Broadcast(),
-              routeTableUpdateInterval = 1.second
+              routeTableUpdateMachineInterval = 1.second
             )
           ),
           static = StaticCenterConfig(
@@ -36,16 +36,16 @@ class CenterConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Info,
             logLevelColor = true,
             logSuppressionList = Seq(),
-            actorTimeout = 30.seconds,
+            actorMachineTimeout = 30.seconds,
             subscribeBatchSize = 100,
-            subscribeBatchInterval = 100.millis,
+            subscribeBatchMachineInterval = 100.millis,
             subscribeBufferSize = 1000
           )
         )
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"atlas":{"culling":{"type":"Broadcast"},"routeTableUpdateInterval":"1s"}},"static":{"actorTimeout":"30s","clock":{"start":{"clockSpeed":1.0,"condition":{"schedule":{"nanos":0,"seconds":0},"type":"Schedule"},"initialTime":{"relative":{"nanos":0,"seconds":0},"type":"Relative"}}},"host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8080,"portAutoIncrement":false,"portAutoIncrementMax":0,"runIdPrefix":"test","subscribeBatchInterval":"100ms","subscribeBatchSize":100,"subscribeBufferSize":1000}}"""
+          json == """{"dynamic":{"atlas":{"culling":{"type":"Broadcast"},"routeTableUpdateMachineInterval":"1s"}},"static":{"actorMachineTimeout":"30s","clock":{"start":{"clockSpeed":1.0,"condition":{"schedule":{"nanos":0,"seconds":0},"type":"Schedule"},"initialTime":{"relative":{"nanos":0,"seconds":0},"type":"Relative"}}},"host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8080,"portAutoIncrement":false,"portAutoIncrementMax":0,"runIdPrefix":"test","subscribeBatchMachineInterval":"100ms","subscribeBatchSize":100,"subscribeBufferSize":1000}}"""
         )
 
     describe("validated"):
@@ -54,7 +54,7 @@ class CenterConfigSpec extends AnyFunSpec:
           dynamic = DynamicCenterConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.GridCulling(Vector3Enu(1, 1, 1)),
-              routeTableUpdateInterval = 1.second
+              routeTableUpdateMachineInterval = 1.second
             )
           ),
           static = StaticCenterConfig(
@@ -73,9 +73,9 @@ class CenterConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Debug,
             logLevelColor = false,
             logSuppressionList = Seq("org.apache.pekko"),
-            actorTimeout = 60.seconds,
+            actorMachineTimeout = 60.seconds,
             subscribeBatchSize = 50,
-            subscribeBatchInterval = 200.millis,
+            subscribeBatchMachineInterval = 200.millis,
             subscribeBufferSize = 500
           )
         )
@@ -87,7 +87,7 @@ class CenterConfigSpec extends AnyFunSpec:
           dynamic = DynamicCenterConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.GridCulling(Vector3Enu(0, -1, 1)),
-              routeTableUpdateInterval = 0.seconds
+              routeTableUpdateMachineInterval = 0.seconds
             )
           ),
           static = StaticCenterConfig(
@@ -106,9 +106,9 @@ class CenterConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Error,
             logLevelColor = true,
             logSuppressionList = Seq(),
-            actorTimeout = 0.seconds,
+            actorMachineTimeout = 0.seconds,
             subscribeBatchSize = 0,
-            subscribeBatchInterval = 0.seconds,
+            subscribeBatchMachineInterval = 0.seconds,
             subscribeBufferSize = 0
           )
         )
@@ -118,16 +118,16 @@ class CenterConfigSpec extends AnyFunSpec:
         assert(
           result.swap.getOrElse(NonEmptyChain.one("")).toChain.toVector.toSet == Set(
             "test.dynamic.atlas.culling.gridCellSize.{x, y, z} must be > 0",
-            "test.dynamic.atlas.routeTableUpdateInterval must be > 0",
+            "test.dynamic.atlas.routeTableUpdateMachineInterval must be > 0",
             "test.static.clock.start.clockSpeed must be >= 0",
             "test.static.clock.start.condition.schedule must be >= 0",
             "test.static.runIdPrefix must not be empty",
             "test.static.host must not be empty",
             "test.static.port must be > 0",
             "test.static.portAutoIncrementMax must be >= 0",
-            "test.static.actorTimeout must be > 0",
+            "test.static.actorMachineTimeout must be > 0",
             "test.static.subscribeBatchSize must be > 0",
-            "test.static.subscribeBatchInterval must be > 0",
+            "test.static.subscribeBatchMachineInterval must be > 0",
             "test.static.subscribeBufferSize must be > 0"
           )
         )

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -45,8 +45,8 @@ arktwin {
         io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler,
         "sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter$"
       ]
-      actorTimeout = 90ms
-      endpointTimeout = 100ms
+      actorMachineTimeout = 90ms
+      endpointMachineTimeout = 100ms
       clockInitialStashSize = 100
       publishBatchSize = 100
       publishBufferSize = 10000

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -131,7 +131,7 @@ object Edge:
       )
       given ExecutionContextExecutor = actorSystem.executionContext
       given Scheduler = actorSystem.scheduler
-      given Timeout = config.static.actorTimeout
+      given Timeout = config.static.actorMachineTimeout
 
       scribe.info(BuildInfo.toString)
       scribe.info(config.toJson)

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeAgentsPutAdapter.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeAgentsPutAdapter.scala
@@ -116,7 +116,7 @@ object EdgeAgentsPutAdapter:
       staticConfig: StaticEdgeConfig,
       coordinateConfig: CoordinateConfig
   ): Behavior[SessionMessage] = Behaviors.setupWithLogger: (context, logger) =>
-    context.setReceiveTimeout(staticConfig.actorTimeout, Timeout)
+    context.setReceiveTimeout(staticConfig.actorMachineTimeout, Timeout)
 
     clock ! Clock.Read(context.self)
     var clockWait = Option.empty[ClockBase]

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeNeighborsQueryAdapter.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeNeighborsQueryAdapter.scala
@@ -82,7 +82,7 @@ object EdgeNeighborsQueryAdapter:
                 clock,
                 register,
                 virtualLatencyHistogram,
-                staticConfig.actorTimeout,
+                staticConfig.actorMachineTimeout,
                 coordinateConfig
               )
             )
@@ -99,7 +99,7 @@ object EdgeNeighborsQueryAdapter:
                 clock,
                 register,
                 virtualLatencyHistogram,
-                staticConfig.actorTimeout,
+                staticConfig.actorMachineTimeout,
                 coordinateConfig
               )
             )

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/StaticEdgeConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/StaticEdgeConfig.scala
@@ -19,8 +19,8 @@ case class StaticEdgeConfig(
     logLevel: LogLevel,
     logLevelColor: Boolean,
     logSuppressionList: Seq[String],
-    actorTimeout: FiniteDuration,
-    endpointTimeout: FiniteDuration,
+    actorMachineTimeout: FiniteDuration,
+    endpointMachineTimeout: FiniteDuration,
     clockInitialStashSize: Int,
     publishBatchSize: Int,
     publishBufferSize: Int
@@ -56,14 +56,14 @@ case class StaticEdgeConfig(
       valid(logLevelColor),
       valid(logSuppressionList),
       condNec(
-        actorTimeout > 0.second,
-        actorTimeout,
-        s"$path.actorTimeout must be > 0"
+        actorMachineTimeout > 0.second,
+        actorMachineTimeout,
+        s"$path.actorMachineTimeout must be > 0"
       ),
       condNec(
-        endpointTimeout > 0.second,
-        endpointTimeout,
-        s"$path.endpointTimeout must be > 0"
+        endpointMachineTimeout > 0.second,
+        endpointMachineTimeout,
+        s"$path.endpointMachineTimeout must be > 0"
       ),
       condNec(
         clockInitialStashSize > 0,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
@@ -102,7 +102,7 @@ object EdgeAgentsPut:
     val agentNumCounter = kamon.restAgentNumCounter(endpoint.showShort)
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
-    given Timeout = staticConfig.endpointTimeout
+    given Timeout = staticConfig.endpointMachineTimeout
     PekkoHttpServerInterpreter().toRoute:
       endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeBulk.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeBulk.scala
@@ -72,7 +72,7 @@ object EdgeBulk:
     val requestNumCounter = kamon.restRequestNumCounter(endpoint.showShort)
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
-    given Timeout = staticConfig.endpointTimeout
+    given Timeout = staticConfig.endpointMachineTimeout
     PekkoHttpServerInterpreter().toRoute:
       endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -43,8 +43,8 @@ object EdgeConfigGet:
       logLevel = LogLevel.Info,
       logLevelColor = true,
       logSuppressionList = Seq(),
-      actorTimeout = 90.milliseconds,
-      endpointTimeout = 100.milliseconds,
+      actorMachineTimeout = 90.milliseconds,
+      endpointMachineTimeout = 100.milliseconds,
       clockInitialStashSize = 100,
       publishBatchSize = 100,
       publishBufferSize = 10000
@@ -72,7 +72,7 @@ object EdgeConfigGet:
     val requestNumCounter = kamon.restRequestNumCounter(endpoint.showShort)
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
-    given Timeout = staticConfig.endpointTimeout
+    given Timeout = staticConfig.endpointMachineTimeout
     PekkoHttpServerInterpreter().toRoute:
       endpoint.serverLogicWithLog: _ =>
         val requestTime = TaggedTimestamp.machineNow()

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
@@ -84,7 +84,7 @@ object EdgeNeighborsQuery:
     val requestNumCounter = kamon.restRequestNumCounter(endpoint.showShort)
     val processMachineTimeHistogram = kamon.restProcessMachineTimeHistogram(endpoint.showShort)
 
-    given Timeout = staticConfig.endpointTimeout
+    given Timeout = staticConfig.endpointMachineTimeout
     PekkoHttpServerInterpreter().toRoute:
       endpoint.serverLogicWithLog: request =>
         val requestTime = TaggedTimestamp.machineNow()

--- a/arktwin/edge/src/main/scala/arktwin/edge/util/EdgeKamon.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/util/EdgeKamon.scala
@@ -61,4 +61,4 @@ object EdgeKamon:
   inline val restRequestNumName = "arktwin_edge_rest_request_num"
   inline val restAgentNumName = "arktwin_edge_rest_agent_num"
   inline val restProcessMachineTimeName = "arktwin_edge_rest_process_machine_time"
-  inline val restVirtualLatencyName = "arktwin_edge_rest_virtual_latency"
+  inline val restVirtualLatencyName = "arktwin_edge_rest_latency"

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -48,8 +48,8 @@ class EdgeConfiguratorSpec extends ActorTestBase:
       logLevel = LogLevel.Info,
       logLevelColor = true,
       logSuppressionList = Seq(),
-      actorTimeout = 90.milliseconds,
-      endpointTimeout = 100.milliseconds,
+      actorMachineTimeout = 90.milliseconds,
+      endpointMachineTimeout = 100.milliseconds,
       clockInitialStashSize = 100,
       publishBatchSize = 100,
       publishBufferSize = 10000

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
@@ -24,8 +24,8 @@ class ClockSpec extends ActorTestBase:
     logLevel = LogLevel.Info,
     logLevelColor = true,
     logSuppressionList = Seq(),
-    actorTimeout = 90.milliseconds,
-    endpointTimeout = 100.milliseconds,
+    actorMachineTimeout = 90.milliseconds,
+    endpointMachineTimeout = 100.milliseconds,
     clockInitialStashSize = 100,
     publishBatchSize = 100,
     publishBufferSize = 10000

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -40,8 +40,8 @@ class EdgeConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Info,
             logLevelColor = true,
             logSuppressionList = Seq(),
-            actorTimeout = 30.seconds,
-            endpointTimeout = 10.seconds,
+            actorMachineTimeout = 30.seconds,
+            endpointMachineTimeout = 10.seconds,
             clockInitialStashSize = 100,
             publishBatchSize = 50,
             publishBufferSize = 500
@@ -50,7 +50,7 @@ class EdgeConfigSpec extends AnyFunSpec:
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}},"culling":{"edgeCulling":true,"maxFirstAgents":100}},"static":{"actorTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
+          json == """{"dynamic":{"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}},"culling":{"edgeCulling":true,"maxFirstAgents":100}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
         )
 
     describe("validated"):
@@ -86,8 +86,8 @@ class EdgeConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Debug,
             logLevelColor = false,
             logSuppressionList = Seq("org.apache.pekko"),
-            actorTimeout = 60.seconds,
-            endpointTimeout = 20.seconds,
+            actorMachineTimeout = 60.seconds,
+            endpointMachineTimeout = 20.seconds,
             clockInitialStashSize = 200,
             publishBatchSize = 100,
             publishBufferSize = 1000
@@ -124,8 +124,8 @@ class EdgeConfigSpec extends AnyFunSpec:
             logLevel = LogLevel.Error,
             logLevelColor = true,
             logSuppressionList = Seq(),
-            actorTimeout = 0.seconds,
-            endpointTimeout = 0.seconds,
+            actorMachineTimeout = 0.seconds,
+            endpointMachineTimeout = 0.seconds,
             clockInitialStashSize = 0,
             publishBatchSize = 0,
             publishBufferSize = 0
@@ -142,8 +142,8 @@ class EdgeConfigSpec extends AnyFunSpec:
             "test.static.host must not be empty",
             "test.static.port must be > 0",
             "test.static.portAutoIncrementMax must be >= 0",
-            "test.static.actorTimeout must be > 0",
-            "test.static.endpointTimeout must be > 0",
+            "test.static.actorMachineTimeout must be > 0",
+            "test.static.endpointMachineTimeout must be > 0",
             "test.static.clockInitialStashSize must be > 0",
             "test.static.publishBatchSize must be > 0",
             "test.static.publishBufferSize must be > 0"


### PR DESCRIPTION
- center config
  - routeTableUpdateInterval -> routeTableUpdateMachineInterval
  - actorTimeout -> actorMachineTimeout
  - subscribeBatchInterval -> subscribeBatchMachineInterval
- edge config
  - actorTimeout -> actorMachineTimeout
  - endpointTimeout -> endpointMachineTimeout
- center metrics
  - arktwin_center_chart_3_route_machine_from_publish_machine_latency -> arktwin_center_chart_3_route_from_publish_machine_latency
- edge metrics
  - arktwin_edge_rest_virtual_latency -> arktwin_edge_rest_latency