### PR TITLE
Add neighbor expiration feature and change Chart configurationNeighbor expiration

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: arktwin
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: arktwin/pages/dist
 

--- a/.github/workflows/scala-ci.yaml
+++ b/.github/workflows/scala-ci.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
@@ -111,7 +111,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin

--- a/arktwin/build.sbt
+++ b/arktwin/build.sbt
@@ -84,6 +84,7 @@ lazy val common = (project in file("common"))
       "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
     ),
+    Compile / managedSourceDirectories += (Compile / pekkoGrpcCodeGeneratorSettings / target).value,
     Compile / PB.targets +=
       scalapb.validate
         .gen(FlatPackage) -> (Compile / pekkoGrpcCodeGeneratorSettings / target).value,

--- a/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/CenterConfig.scala
@@ -13,8 +13,8 @@ import pureconfig.error.ConfigReaderFailures
 import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
 
 case class CenterConfig(
-    dynamic: DynamicCenterConfig,
-    static: StaticCenterConfig
+    dynamic: CenterDynamicConfig,
+    static: CenterStaticConfig
 ) derives ConfigReader:
   def toJson: String =
     given ConfigWriter[CenterConfig] = deriveWriter

--- a/arktwin/center/src/main/scala/arktwin/center/configs/CenterDynamicConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/CenterDynamicConfig.scala
@@ -5,8 +5,8 @@ package arktwin.center.configs
 import cats.data.ValidatedNec
 
 // TODO changeable via Admin API
-case class DynamicCenterConfig(
+case class CenterDynamicConfig(
     atlas: AtlasConfig
 ):
-  def validated(path: String): ValidatedNec[String, DynamicCenterConfig] =
-    atlas.validated(s"$path.atlas").map(DynamicCenterConfig.apply)
+  def validated(path: String): ValidatedNec[String, CenterDynamicConfig] =
+    atlas.validated(s"$path.atlas").map(CenterDynamicConfig.apply)

--- a/arktwin/center/src/main/scala/arktwin/center/configs/CenterStaticConfig.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/configs/CenterStaticConfig.scala
@@ -8,7 +8,7 @@ import cats.data.ValidatedNec
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-case class StaticCenterConfig(
+case class CenterStaticConfig(
     actorMachineTimeout: FiniteDuration,
     clock: ClockConfig,
     host: String,
@@ -23,7 +23,7 @@ case class StaticCenterConfig(
     subscribeBatchSize: Int,
     subscribeBufferSize: Int
 ):
-  def validated(path: String): ValidatedNec[String, StaticCenterConfig] =
+  def validated(path: String): ValidatedNec[String, CenterStaticConfig] =
     import cats.syntax.apply.*
     (
       condNec(
@@ -71,4 +71,4 @@ case class StaticCenterConfig(
         subscribeBufferSize,
         s"$path.subscribeBufferSize must be > 0"
       )
-    ).mapN(StaticCenterConfig.apply)
+    ).mapN(CenterStaticConfig.apply)

--- a/arktwin/center/src/main/scala/arktwin/center/services/ChartService.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/services/ChartService.scala
@@ -3,7 +3,7 @@
 package arktwin.center.services
 
 import arktwin.center.actors.*
-import arktwin.center.configs.StaticCenterConfig
+import arktwin.center.configs.CenterStaticConfig
 import arktwin.center.util.CenterKamon
 import arktwin.common.data.TaggedTimestamp
 import arktwin.common.data.TimestampExtensions.*
@@ -24,7 +24,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ChartService(
     atlas: ActorRef[Atlas.Message],
-    config: StaticCenterConfig,
+    config: CenterStaticConfig,
     kamon: CenterKamon
 )(using
     Materializer,

--- a/arktwin/center/src/main/scala/arktwin/center/services/ClockService.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/services/ClockService.scala
@@ -8,18 +8,27 @@ import arktwin.common.util.GrpcHeaderKeys
 import arktwin.common.util.SourceExtensions.*
 import com.google.protobuf.empty.Empty
 import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.actor.typed.scaladsl.AskPattern.Askable
+import org.apache.pekko.actor.typed.{ActorRef, Scheduler}
 import org.apache.pekko.grpc.scaladsl.Metadata
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.typed.scaladsl.ActorSource
 import org.apache.pekko.stream.{Materializer, OverflowStrategy}
+import org.apache.pekko.util.Timeout
+
+import scala.concurrent.Future
 
 class ClockService(
     clock: ActorRef[Clock.Message],
     config: CenterStaticConfig
 )(using
-    Materializer
+    Materializer,
+    Scheduler,
+    Timeout
 ) extends ClockPowerApi:
+  override def read(in: Empty, metadata: Metadata): Future[ClockBase] =
+    clock ? (Clock.Read(_))
+
   override def subscribe(in: Empty, metadata: Metadata): Source[ClockBase, NotUsed] =
     val edgeId = metadata.getText(GrpcHeaderKeys.edgeId).getOrElse("")
 

--- a/arktwin/center/src/main/scala/arktwin/center/services/ClockService.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/services/ClockService.scala
@@ -3,7 +3,7 @@
 package arktwin.center.services
 
 import arktwin.center.actors.Clock
-import arktwin.center.configs.StaticCenterConfig
+import arktwin.center.configs.CenterStaticConfig
 import arktwin.common.util.GrpcHeaderKeys
 import arktwin.common.util.SourceExtensions.*
 import com.google.protobuf.empty.Empty
@@ -16,7 +16,7 @@ import org.apache.pekko.stream.{Materializer, OverflowStrategy}
 
 class ClockService(
     clock: ActorRef[Clock.Message],
-    config: StaticCenterConfig
+    config: CenterStaticConfig
 )(using
     Materializer
 ) extends ClockPowerApi:

--- a/arktwin/center/src/main/scala/arktwin/center/services/RegisterService.scala
+++ b/arktwin/center/src/main/scala/arktwin/center/services/RegisterService.scala
@@ -3,7 +3,7 @@
 package arktwin.center.services
 
 import arktwin.center.actors.Register
-import arktwin.center.configs.StaticCenterConfig
+import arktwin.center.configs.CenterStaticConfig
 import arktwin.common.util.CommonMessages.Nop
 import arktwin.common.util.GrpcHeaderKeys
 import arktwin.common.util.SourceExtensions.*
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 
 class RegisterService(
     register: ActorRef[Register.Message],
-    config: StaticCenterConfig
+    config: CenterStaticConfig
 )(using
     Materializer,
     Scheduler,

--- a/arktwin/center/src/test/scala/arktwin/center/configs/CenterConfigSpec.scala
+++ b/arktwin/center/src/test/scala/arktwin/center/configs/CenterConfigSpec.scala
@@ -14,13 +14,13 @@ class CenterConfigSpec extends AnyFunSpec:
     describe("toJson"):
       it("converts config to JSON string"):
         val config = CenterConfig(
-          dynamic = DynamicCenterConfig(
+          dynamic = CenterDynamicConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.Broadcast(),
               routeTableUpdateMachineInterval = 1.second
             )
           ),
-          static = StaticCenterConfig(
+          static = CenterStaticConfig(
             actorMachineTimeout = 30.seconds,
             clock = ClockConfig(
               start = ClockConfig.Start(
@@ -51,13 +51,13 @@ class CenterConfigSpec extends AnyFunSpec:
     describe("validated"):
       it("returns valid config when all fields are valid"):
         val config = CenterConfig(
-          dynamic = DynamicCenterConfig(
+          dynamic = CenterDynamicConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.GridCulling(Vector3Enu(1, 1, 1)),
               routeTableUpdateMachineInterval = 1.second
             )
           ),
-          static = StaticCenterConfig(
+          static = CenterStaticConfig(
             actorMachineTimeout = 60.seconds,
             clock = ClockConfig(
               start = ClockConfig.Start(
@@ -84,13 +84,13 @@ class CenterConfigSpec extends AnyFunSpec:
 
       it("returns invalid with error messages when fields are invalid"):
         val config = CenterConfig(
-          dynamic = DynamicCenterConfig(
+          dynamic = CenterDynamicConfig(
             atlas = AtlasConfig(
               culling = AtlasConfig.GridCulling(Vector3Enu(0, -1, 1)),
               routeTableUpdateMachineInterval = 0.seconds
             )
           ),
-          static = StaticCenterConfig(
+          static = CenterStaticConfig(
             actorMachineTimeout = 0.seconds,
             clock = ClockConfig(
               start = ClockConfig.Start(

--- a/arktwin/common/src/main/protobuf/arktwin/center/services/clock.proto
+++ b/arktwin/common/src/main/protobuf/arktwin/center/services/clock.proto
@@ -7,6 +7,7 @@ import "google/protobuf/empty.proto";
 import "validate/validate.proto";
 
 service Clock {
+  rpc Read(google.protobuf.Empty) returns (ClockBase);
   rpc Subscribe(google.protobuf.Empty) returns (stream ClockBase);
 }
 

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/AtOnceSimulation.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/AtOnceSimulation.scala
@@ -11,8 +11,8 @@ class AtOnceSimulation extends Simulation:
     Seq(
       CenterClockSpeedPutScenario.builder,
       EdgeAgentsPostScenario.builder,
-      EdgeConfigCoordinatePutScenario.builder,
-      EdgeConfigCullingPutScenario.builder
+      EdgeConfigChartPutScenario.builder,
+      EdgeConfigCoordinatePutScenario.builder
     ).map(_.inject(atOnceUsers(1))).reduceRight(_ andThen _)
   ).protocols(http.baseUrl("http://localhost:2237"))
     .assertions(global.failedRequests.count.is(0))

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeAgentsPostScenario.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeAgentsPostScenario.scala
@@ -11,11 +11,11 @@ object EdgeAgentsPostScenario:
   val builder: ScenarioBuilder =
     def requests(n: Int)(agentIdPrefix: String, kind: String): String = Seq
       .fill(n)(s"""{
-        |  "agentIdPrefix": "$agentIdPrefix",
-        |  "kind": "$kind",
-        |  "status": {},
-        |  "assets": {}
-        |}""".stripMargin.filterNot(_.isWhitespace))
+        |"agentIdPrefix":"$agentIdPrefix",
+        |"kind":"$kind",
+        |"status":{},
+        |"assets":{}
+        |}""".stripMargin.linesIterator.mkString)
       .mkString("[", ",", "]")
 
     scenario(getClass.getSimpleName)

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
@@ -12,11 +12,15 @@ object EdgeConfigChartPutScenario:
   val builder: ScenarioBuilder =
     val chartConfig =
       """{
-        |"culling":true,
-        |"cullingMaxFirstAgents":123,
-        |"expiration":true,
-        |"expirationCheckMachineInterval":"10 seconds",
-        |"expirationTimeout":"20 seconds"
+        |"culling":{
+        |"enabled":true,
+        |"maxFirstAgents":123
+        |},
+        |"expiration":{
+        |"enabled":true,
+        |"checkMachineInterval":"10 seconds",
+        |"timeout":"20 seconds"
+        |}
         |}""".stripMargin.linesIterator.mkString
 
     scenario(getClass.getSimpleName)

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
@@ -8,9 +8,9 @@ import io.gatling.http.Predef.*
 
 import scala.concurrent.duration.DurationInt
 
-object EdgeConfigCullingPutScenario:
+object EdgeConfigChartPutScenario:
   val builder: ScenarioBuilder =
-    val cullingConfig =
+    val chartConfig =
       """{
         |  "edgeCulling": true,
         |  "maxFirstAgents": 123
@@ -19,8 +19,8 @@ object EdgeConfigCullingPutScenario:
     scenario(getClass.getSimpleName)
       .exec(
         http(_.scenario)
-          .put("/api/edge/config/culling")
-          .body(StringBody(cullingConfig))
+          .put("/api/edge/config/chart")
+          .body(StringBody(chartConfig))
           .check(status.is(202))
       )
       .pause(10.millis)
@@ -28,5 +28,5 @@ object EdgeConfigCullingPutScenario:
         http(_.scenario)
           .get("/api/edge/config")
           .check(status.is(200))
-          .check(jsonPath("$.dynamic.culling").find.is(cullingConfig))
+          .check(jsonPath("$.dynamic.chart").find.is(chartConfig))
       )

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigChartPutScenario.scala
@@ -12,9 +12,12 @@ object EdgeConfigChartPutScenario:
   val builder: ScenarioBuilder =
     val chartConfig =
       """{
-        |  "edgeCulling": true,
-        |  "maxFirstAgents": 123
-        |}""".stripMargin.filterNot(_.isWhitespace)
+        |"culling":true,
+        |"cullingMaxFirstAgents":123,
+        |"expiration":true,
+        |"expirationCheckMachineInterval":"10 seconds",
+        |"expirationTimeout":"20 seconds"
+        |}""".stripMargin.linesIterator.mkString
 
     scenario(getClass.getSimpleName)
       .exec(

--- a/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigCoordinatePutScenario.scala
+++ b/arktwin/e2e/src/test/scala/arktwin/e2e/endpoints/EdgeConfigCoordinatePutScenario.scala
@@ -12,26 +12,26 @@ object EdgeConfigCoordinatePutScenario:
   val builder: ScenarioBuilder =
     val coordinateConfig =
       """{
-      |  "axis": {
-      |    "xDirection": "North",
-      |    "yDirection": "East",
-      |    "zDirection": "Down"
-      |  },
-      |  "centerOrigin": {
-      |    "x": 1.1,
-      |    "y": 2.3,
-      |    "z": 4.5
-      |  },
-      |  "lengthUnit": "Millimeter",
-      |  "rotation": {
-      |    "EulerAnglesConfig": {
-      |      "angleUnit": "Degree",
-      |      "rotationMode": "Extrinsic",
-      |      "rotationOrder": "ZXY"
-      |    }
-      |  },
-      |  "speedUnit": "KilometerPerHour"
-      |}""".stripMargin.filterNot(_.isWhitespace)
+      |"axis":{
+      |"xDirection":"North",
+      |"yDirection":"East",
+      |"zDirection":"Down"
+      |},
+      |"centerOrigin":{
+      |"x":1.1,
+      |"y":2.3,
+      |"z":4.5
+      |},
+      |"lengthUnit":"Millimeter",
+      |"rotation":{
+      |"EulerAnglesConfig":{
+      |"angleUnit":"Degree",
+      |"rotationMode":"Extrinsic",
+      |"rotationOrder":"ZXY"
+      |}
+      |},
+      |"speedUnit":"KilometerPerHour"
+      |}""".stripMargin.linesIterator.mkString
 
     scenario(getClass.getSimpleName)
       .exec(

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -2,8 +2,11 @@ arktwin {
   edge {
     dynamic {
       chart {
-        edgeCulling = true
-        maxFirstAgents = 9
+        culling = true
+        cullingMaxFirstAgents = 9
+        expiration = false
+        expirationCheckMachineInterval = 1s
+        expirationTimeout = 3s
       }
       coordinate {
         axis {

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -2,11 +2,15 @@ arktwin {
   edge {
     dynamic {
       chart {
-        culling = true
-        cullingMaxFirstAgents = 9
-        expiration = false
-        expirationCheckMachineInterval = 1s
-        expirationTimeout = 3s
+        culling {
+          enabled = true
+          maxFirstAgents = 9
+        }
+        expiration {
+          enabled = false
+          checkMachineInterval = 1s
+          timeout = 3s
+        }
       }
       coordinate {
         axis {

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -1,6 +1,10 @@
 arktwin {
   edge {
     dynamic {
+      chart {
+        edgeCulling = true
+        maxFirstAgents = 9
+      }
       coordinate {
         axis {
           xDirection = East
@@ -20,10 +24,6 @@ arktwin {
           rotationOrder = XYZ
         }
         speedUnit = MeterPerSecond
-      }
-      culling {
-        edgeCulling = true
-        maxFirstAgents = 9
       }
     }
     static {

--- a/arktwin/edge/src/main/resources/reference.conf
+++ b/arktwin/edge/src/main/resources/reference.conf
@@ -31,7 +31,6 @@ arktwin {
     }
     static {
       actorMachineTimeout = 90ms
-      clockInitialStashSize = 100
       edgeIdPrefix = edge
       edgeIdPrefix = ${?ARKTWIN_EDGE_STATIC_EDGE_ID_PREFIX}
       endpointMachineTimeout = 100ms

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -48,8 +48,8 @@ object Edge:
         EdgeAgentsPost.endpoint,
         EdgeAgentsPut.endpoint,
         EdgeBulk.endpoint,
+        EdgeConfigChartPut.endpoint,
         EdgeConfigCoordinatePut.endpoint,
-        EdgeConfigCullingPut.endpoint,
         EdgeConfigGet.endpoint,
         EdgeNeighborsQuery.endpoint
       ),
@@ -163,7 +163,7 @@ object Edge:
       for
         clock <- actorSystem ? Clock.spawn(config.static)
         register <- actorSystem ? Register.spawn()
-        chart <- actorSystem ? Chart.spawn(config.dynamic.culling)
+        chart <- actorSystem ? Chart.spawn(config.dynamic.chart)
         configurator <- actorSystem ? EdgeConfigurator.spawn(config)
         chartPublish = chartConnector.publish()
         registerPublish = registerConnector.publish()
@@ -215,8 +215,8 @@ object Edge:
                 EdgeAgentsPut.route(edgeAgentsTransformAdapter, config.static, kamon) ~
                 EdgeBulk
                   .route(edgeAgentsTransformAdapter, edgeNeighborsAdapter, config.static, kamon) ~
+                EdgeConfigChartPut.route(configurator, kamon) ~
                 EdgeConfigCoordinatePut.route(configurator, kamon) ~
-                EdgeConfigCullingPut.route(configurator, kamon) ~
                 EdgeConfigGet.route(configurator, config.static, kamon) ~
                 EdgeNeighborsQuery.route(edgeNeighborsAdapter, config.static, kamon) ~
                 path("metrics")(complete(PrometheusReporter.latestScrapeData())) ~

--- a/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/Edge.scala
@@ -167,7 +167,7 @@ object Edge:
       for
         clock <- actorSystem ? Clock.spawn(initClockBase)
         register <- actorSystem ? Register.spawn()
-        chart <- actorSystem ? Chart.spawn(config.dynamic.chart)
+        chart <- actorSystem ? Chart.spawn(initClockBase, config.dynamic.chart)
         configurator <- actorSystem ? EdgeConfigurator.spawn(config)
         chartPublish = chartConnector.publish()
         registerPublish = registerConnector.publish()

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeAgentsPutAdapter.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeAgentsPutAdapter.scala
@@ -11,7 +11,7 @@ import arktwin.common.util.{MailboxConfig, VirtualDurationHistogram}
 import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.actors.EdgeConfigurator.UpdateCoordinateConfig
 import arktwin.edge.actors.sinks.{Chart, Clock}
-import arktwin.edge.configs.{CoordinateConfig, StaticEdgeConfig}
+import arktwin.edge.configs.{CoordinateConfig, EdgeStaticConfig}
 import arktwin.edge.connectors.{ChartConnector, RegisterConnector}
 import arktwin.edge.endpoints.EdgeAgentsPut
 import arktwin.edge.endpoints.EdgeAgentsPut.{Request, Response}
@@ -36,7 +36,7 @@ object EdgeAgentsPutAdapter:
       chartPublish: ActorRef[ChartConnector.Publish],
       registerPublish: ActorRef[RegisterConnector.Publish],
       clock: ActorRef[Clock.Read],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       initCoordinateConfig: CoordinateConfig,
       kamon: EdgeKamon
   ): ActorRef[ActorRef[Message]] => Spawn[Message] =
@@ -52,7 +52,7 @@ object EdgeAgentsPutAdapter:
       chartPublish: ActorRef[ChartConnector.Publish],
       registerPublish: ActorRef[RegisterConnector.Publish],
       clock: ActorRef[Clock.Read],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       initCoordinateConfig: CoordinateConfig,
       kamon: EdgeKamon
   ): Behavior[Message] = Behaviors.setup: context =>
@@ -113,7 +113,7 @@ object EdgeAgentsPutAdapter:
       registerPublish: ActorRef[RegisterConnector.Publish],
       clock: ActorRef[Clock.Read],
       virtualLatencyHistogram: VirtualDurationHistogram,
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       coordinateConfig: CoordinateConfig
   ): Behavior[SessionMessage] = Behaviors.setupWithLogger: (context, logger) =>
     context.setReceiveTimeout(staticConfig.actorMachineTimeout, Timeout)

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeNeighborsQueryAdapter.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/adapters/EdgeNeighborsQueryAdapter.scala
@@ -13,7 +13,7 @@ import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.actors.EdgeConfigurator.UpdateCoordinateConfig
 import arktwin.edge.actors.sinks.Chart.CullingNeighbor
 import arktwin.edge.actors.sinks.{Chart, Clock, Register}
-import arktwin.edge.configs.{CoordinateConfig, StaticEdgeConfig}
+import arktwin.edge.configs.{CoordinateConfig, EdgeStaticConfig}
 import arktwin.edge.data.Transform
 import arktwin.edge.endpoints.EdgeNeighborsQuery.{Request, Response, ResponseAgent}
 import arktwin.edge.endpoints.{EdgeNeighborsQuery, NeighborChange}
@@ -39,7 +39,7 @@ object EdgeNeighborsQueryAdapter:
       chart: ActorRef[Chart.Read],
       clock: ActorRef[Clock.Read],
       register: ActorRef[Register.Get],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       initCoordinateConfig: CoordinateConfig,
       kamon: EdgeKamon
   ): ActorRef[ActorRef[Message]] => Spawn[Message] =
@@ -54,7 +54,7 @@ object EdgeNeighborsQueryAdapter:
       chart: ActorRef[Chart.Read],
       clock: ActorRef[Clock.Read],
       register: ActorRef[Register.Get],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       initCoordinateConfig: CoordinateConfig,
       kamon: EdgeKamon
   ): Behavior[Message] = Behaviors.setup: context =>

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
@@ -77,13 +77,13 @@ object Chart:
         Behaviors.same
 
       case UpdateFirstAgents(newFirstAgents) =>
-        if chartConfig.edgeCulling then
-          if newFirstAgents.size <= chartConfig.maxFirstAgents
+        if chartConfig.culling then
+          if newFirstAgents.size <= chartConfig.cullingMaxFirstAgents
           then firstAgents = Some(newFirstAgents)
           else
             if firstAgents.isDefined then
               logger.warn(
-                "edge culling is disabled because first agents is greater than arktwin.edge.dynamic.chart.maxFirstAgents"
+                "edge culling is disabled because first agents is greater than arktwin.edge.dynamic.chart.cullingMaxFirstAgents"
               )
             firstAgents = None
         else firstAgents = None

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Chart.scala
@@ -2,15 +2,17 @@
 // Copyright 2024-2025 TOYOTA MOTOR CORPORATION
 package arktwin.edge.actors.sinks
 
-import arktwin.center.services.ChartAgent
-import arktwin.common.data.TaggedTimestamp
+import arktwin.center.services.ClockBaseExtensions.now
+import arktwin.center.services.{ChartAgent, ClockBase}
 import arktwin.common.data.TimestampExtensions.*
 import arktwin.common.data.Vector3EnuExtensions.*
+import arktwin.common.data.{TaggedDuration, TaggedTimestamp}
 import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.CommonMessages.Nop
 import arktwin.common.util.{MailboxConfig, VirtualTag}
 import arktwin.edge.actors.EdgeConfigurator
 import arktwin.edge.actors.EdgeConfigurator.UpdateChartConfig
+import arktwin.edge.actors.sinks.Clock.UpdateClockBase
 import arktwin.edge.configs.ChartConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.receptionist.Receptionist
@@ -23,89 +25,136 @@ import scala.collection.mutable
 /** An actor that manages transform data of neighbors.
   *
   * # Message Protocol
+  *   - `DeleteExpiredNeighbors`: Delete expired neighbors
   *   - `Nop`: No operation
   *   - `Read`: Reads transform data of neighbors sorted by distance from first agents when edge
   *     culling is enabled
   *   - `UpdateChartConfig`: Updates the chart configuration
+  *   - `UpdateClockBase`: Updates the clock base and distributes it to registered clock observers
   *   - `UpdateFirstAgents`: Updates first agents used as reference points for distance calculations
   *   - `UpdateNeighbor`: Updates neighbor and sorts neighbors by distance from first agents when
   *     edge culling is enabled
   */
 object Chart:
-  type Message = Nop.type | Read | UpdateChartConfig | UpdateFirstAgents | UpdateNeighbor
+  type Message = DeleteExpiredNeighbors.type | Nop.type | Read | UpdateChartConfig |
+    UpdateClockBase | UpdateFirstAgents | UpdateNeighbor
+  object DeleteExpiredNeighbors
   case class Read(replyTo: ActorRef[ReadReply]) extends ControlMessage
   case class UpdateFirstAgents(firstAgents: Seq[ChartAgent])
   case class UpdateNeighbor(neighbor: ChartAgent)
 
-  case class ReadReply(orderedNeighbors: Seq[CullingNeighbor]) extends AnyVal
   case class CullingNeighbor(neighbor: ChartAgent, nearestDistance: Option[Double])
+  case class ReadReply(orderedNeighbors: Seq[CullingNeighbor]) extends AnyVal
 
   def spawn(
+      initClockBase: ClockBase,
       initChartConfig: ChartConfig
   ): ActorRef[ActorRef[Message]] => Spawn[Message] = Spawn(
-    apply(initChartConfig),
+    apply(initClockBase, initChartConfig),
     getClass.getSimpleName,
     MailboxConfig(this),
     _
   )
 
   def apply(
+      initClockBase: ClockBase,
       initChartConfig: ChartConfig
   ): Behavior[Message] = Behaviors.setupWithLogger: (context, logger) =>
+    context.system.receptionist ! Receptionist.Register(
+      Clock.observerKey,
+      context.self
+    )
     context.system.receptionist ! Receptionist.Register(
       EdgeConfigurator.chartObserverKey,
       context.self
     )
 
+    var clockBase = initClockBase
     var chartConfig = initChartConfig
     val distances = mutable.Map[String, Double]()
     val orderedNeighbors = mutable.TreeMap[(Double, String), ChartAgent]()
     var firstAgents = Option(Seq[ChartAgent]())
 
-    Behaviors.receiveMessage:
-      case Nop =>
-        Behaviors.same
+    Behaviors.withTimers: timer =>
+      if chartConfig.expiration.enabled then
+        timer.startSingleTimer(
+          DeleteExpiredNeighbors,
+          DeleteExpiredNeighbors,
+          chartConfig.expiration.checkMachineInterval
+        )
 
-      case Read(actorRef) =>
-        actorRef ! ReadReply(orderedNeighbors.toSeq.map:
-          case ((dist, _), agent) =>
-            CullingNeighbor(agent, Some(dist).filter(_.isFinite)))
-        Behaviors.same
-
-      case UpdateChartConfig(newChartConfig) =>
-        chartConfig = newChartConfig
-        Behaviors.same
-
-      case UpdateFirstAgents(newFirstAgents) =>
-        if chartConfig.culling then
-          if newFirstAgents.size <= chartConfig.cullingMaxFirstAgents
-          then firstAgents = Some(newFirstAgents)
-          else
-            if firstAgents.isDefined then
-              logger.warn(
-                "edge culling is disabled because first agents is greater than arktwin.edge.dynamic.chart.cullingMaxFirstAgents"
-              )
-            firstAgents = None
-        else firstAgents = None
-        Behaviors.same
-
-      case UpdateNeighbor(neighbor) =>
-        val oldDistance = distances.get(neighbor.agentId)
-        val oldTimestamp = oldDistance
-          .map(orderedNeighbors(_, neighbor.agentId).transform.timestamp.tagVirtual)
-          .getOrElse(TaggedTimestamp.minValue[VirtualTag])
-        if neighbor.transform.timestamp.tagVirtual >= oldTimestamp then
-          for od <- oldDistance do orderedNeighbors -= ((od, neighbor.agentId))
-
-          // TODO consider relative coordinates
-          // TODO extrapolate first agents based on previous transforms?
-          val distance = firstAgents
-            .getOrElse(Seq())
-            .map(a =>
-              neighbor.transform.localTranslationMeter.distance(a.transform.localTranslationMeter)
+      Behaviors.receiveMessage:
+        case DeleteExpiredNeighbors =>
+          orderedNeighbors.filterInPlace:
+            case (_, agent) =>
+              val age = clockBase.now() - agent.transform.timestamp.tagVirtual
+              if age > TaggedDuration.from(chartConfig.expiration.timeout) then
+                distances -= agent.agentId
+                false
+              else true
+          if chartConfig.expiration.enabled then
+            timer.startSingleTimer(
+              DeleteExpiredNeighbors,
+              DeleteExpiredNeighbors,
+              chartConfig.expiration.checkMachineInterval
             )
-            .minOption
-            .getOrElse(Double.PositiveInfinity)
-          distances += neighbor.agentId -> distance
-          orderedNeighbors += (distance, neighbor.agentId) -> neighbor
-        Behaviors.same
+          Behaviors.same
+
+        case Nop =>
+          Behaviors.same
+
+        case Read(actorRef) =>
+          actorRef ! ReadReply(orderedNeighbors.toSeq.map:
+            case ((dist, _), agent) =>
+              CullingNeighbor(agent, Some(dist).filter(_.isFinite)))
+          Behaviors.same
+
+        case UpdateClockBase(newClockBase) =>
+          clockBase = newClockBase
+          Behaviors.same
+
+        case UpdateChartConfig(newChartConfig) =>
+          if chartConfig.expiration != newChartConfig.expiration then
+            if newChartConfig.expiration.enabled then
+              timer.startSingleTimer(
+                DeleteExpiredNeighbors,
+                DeleteExpiredNeighbors,
+                newChartConfig.expiration.checkMachineInterval
+              )
+            else timer.cancel(DeleteExpiredNeighbors)
+          chartConfig = newChartConfig
+          Behaviors.same
+
+        case UpdateFirstAgents(newFirstAgents) =>
+          if chartConfig.culling.enabled then
+            if newFirstAgents.size <= chartConfig.culling.maxFirstAgents
+            then firstAgents = Some(newFirstAgents)
+            else
+              if firstAgents.isDefined then
+                logger.warn(
+                  "edge culling is disabled because first agents is greater than arktwin.edge.dynamic.chart.culling.maxFirstAgents"
+                )
+              firstAgents = None
+          else firstAgents = None
+          Behaviors.same
+
+        case UpdateNeighbor(neighbor) =>
+          val oldDistance = distances.get(neighbor.agentId)
+          val oldTimestamp = oldDistance
+            .map(orderedNeighbors(_, neighbor.agentId).transform.timestamp.tagVirtual)
+            .getOrElse(TaggedTimestamp.minValue[VirtualTag])
+          if neighbor.transform.timestamp.tagVirtual >= oldTimestamp then
+            for od <- oldDistance do orderedNeighbors -= ((od, neighbor.agentId))
+
+            // TODO consider relative coordinates
+            // TODO extrapolate first agents based on previous transforms?
+            val distance = firstAgents
+              .getOrElse(Seq())
+              .map(a =>
+                neighbor.transform.localTranslationMeter.distance(a.transform.localTranslationMeter)
+              )
+              .minOption
+              .getOrElse(Double.PositiveInfinity)
+            distances += neighbor.agentId -> distance
+            orderedNeighbors += (distance, neighbor.agentId) -> neighbor
+          Behaviors.same

--- a/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Clock.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/actors/sinks/Clock.scala
@@ -6,7 +6,7 @@ import arktwin.center.services.ClockBase
 import arktwin.common.util.BehaviorsExtensions.*
 import arktwin.common.util.CommonMessages.Nop
 import arktwin.common.util.MailboxConfig
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import org.apache.pekko.actor.typed.SpawnProtocol.Spawn
 import org.apache.pekko.actor.typed.receptionist.Receptionist.Listing
 import org.apache.pekko.actor.typed.receptionist.{Receptionist, ServiceKey}
@@ -29,7 +29,7 @@ object Clock:
 
   val observerKey: ServiceKey[UpdateClockBase] = ServiceKey(getClass.getName)
 
-  def spawn(staticConfig: StaticEdgeConfig): ActorRef[ActorRef[Message]] => Spawn[Message] = Spawn(
+  def spawn(staticConfig: EdgeStaticConfig): ActorRef[ActorRef[Message]] => Spawn[Message] = Spawn(
     apply(staticConfig),
     getClass.getSimpleName,
     MailboxConfig(this),
@@ -37,7 +37,7 @@ object Clock:
   )
 
   def apply(
-      staticConfig: StaticEdgeConfig
+      staticConfig: EdgeStaticConfig
   ): Behavior[Message] = Behaviors.setup: context =>
     Behaviors.withStash(staticConfig.clockInitialStashSize): buffer =>
       context.system.receptionist ! Receptionist.subscribe(observerKey, context.self)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
@@ -9,32 +9,58 @@ import sttp.tapir.Schema.annotations.description
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 case class ChartConfig(
-    @description("If true, edge culling is enabled.")
-    culling: Boolean,
-    @description("If first agents is greater than cullingMaxFirstAgents, edge culling is disabled.")
-    cullingMaxFirstAgents: Int,
-    expiration: Boolean,
-    expirationCheckMachineInterval: FiniteDuration,
-    expirationTimeout: FiniteDuration
+    culling: ChartConfig.Culling,
+    expiration: ChartConfig.Expiration
 ):
   def validated(path: String): ValidatedNec[String, ChartConfig] =
     import cats.syntax.apply.*
     (
-      valid(culling),
-      condNec(
-        cullingMaxFirstAgents >= 0,
-        cullingMaxFirstAgents,
-        s"$path.cullingMaxFirstAgents must be >= 0"
-      ),
-      valid(expiration),
-      condNec(
-        expirationCheckMachineInterval > 0.second,
-        expirationCheckMachineInterval,
-        s"$path.expirationCheckMachineInterval must be > 0"
-      ),
-      condNec(
-        expirationTimeout > 0.second,
-        expirationTimeout,
-        s"$path.expirationTimeout must be > 0"
-      )
+      culling.validated(s"$path.culling"),
+      expiration.validated(s"$path.expiration")
     ).mapN(ChartConfig.apply)
+
+object ChartConfig:
+  case class Culling(
+      @description("If true, edge culling is enabled.")
+      enabled: Boolean,
+      @description(
+        "If first agents is greater than cullingMaxFirstAgents, edge culling is disabled."
+      )
+      maxFirstAgents: Int
+  ):
+    def validated(path: String): ValidatedNec[String, Culling] =
+      import cats.syntax.apply.*
+      (
+        valid(enabled),
+        condNec(
+          maxFirstAgents >= 0,
+          maxFirstAgents,
+          s"$path.maxFirstAgents must be >= 0"
+        )
+      ).mapN(Culling.apply)
+
+  case class Expiration(
+      @description("If true, expired neighbors are automatically deleted from the chart.")
+      enabled: Boolean,
+      @description("Machine time interval to check for expired neighbors in the chart.")
+      checkMachineInterval: FiniteDuration,
+      @description(
+        "Virtual time duration after which a neighbor is considered expired if not updated."
+      )
+      timeout: FiniteDuration
+  ):
+    def validated(path: String): ValidatedNec[String, Expiration] =
+      import cats.syntax.apply.*
+      (
+        valid(enabled),
+        condNec(
+          checkMachineInterval > 0.seconds,
+          checkMachineInterval,
+          s"$path.checkMachineInterval must be > 0"
+        ),
+        condNec(
+          timeout > 0.seconds,
+          timeout,
+          s"$path.timeout must be > 0"
+        )
+      ).mapN(Expiration.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
@@ -6,19 +6,35 @@ import cats.data.Validated.{condNec, valid}
 import cats.data.ValidatedNec
 import sttp.tapir.Schema.annotations.description
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 case class ChartConfig(
     @description("If true, edge culling is enabled.")
-    edgeCulling: Boolean,
-    @description("If first agents is greater than maxFirstAgents, edge culling is disabled.")
-    maxFirstAgents: Int
+    culling: Boolean,
+    @description("If first agents is greater than cullingMaxFirstAgents, edge culling is disabled.")
+    cullingMaxFirstAgents: Int,
+    expiration: Boolean,
+    expirationCheckMachineInterval: FiniteDuration,
+    expirationTimeout: FiniteDuration
 ):
   def validated(path: String): ValidatedNec[String, ChartConfig] =
     import cats.syntax.apply.*
     (
-      valid(edgeCulling),
+      valid(culling),
       condNec(
-        maxFirstAgents >= 0,
-        maxFirstAgents,
-        s"$path.maxFirstAgents must be >= 0"
+        cullingMaxFirstAgents >= 0,
+        cullingMaxFirstAgents,
+        s"$path.cullingMaxFirstAgents must be >= 0"
+      ),
+      valid(expiration),
+      condNec(
+        expirationCheckMachineInterval > 0.second,
+        expirationCheckMachineInterval,
+        s"$path.expirationCheckMachineInterval must be > 0"
+      ),
+      condNec(
+        expirationTimeout > 0.second,
+        expirationTimeout,
+        s"$path.expirationTimeout must be > 0"
       )
     ).mapN(ChartConfig.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/ChartConfig.scala
@@ -6,13 +6,13 @@ import cats.data.Validated.{condNec, valid}
 import cats.data.ValidatedNec
 import sttp.tapir.Schema.annotations.description
 
-case class CullingConfig(
+case class ChartConfig(
     @description("If true, edge culling is enabled.")
     edgeCulling: Boolean,
     @description("If first agents is greater than maxFirstAgents, edge culling is disabled.")
     maxFirstAgents: Int
 ):
-  def validated(path: String): ValidatedNec[String, CullingConfig] =
+  def validated(path: String): ValidatedNec[String, ChartConfig] =
     import cats.syntax.apply.*
     (
       valid(edgeCulling),
@@ -21,4 +21,4 @@ case class CullingConfig(
         maxFirstAgents,
         s"$path.maxFirstAgents must be >= 0"
       )
-    ).mapN(CullingConfig.apply)
+    ).mapN(ChartConfig.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeConfig.scala
@@ -14,8 +14,8 @@ import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
 import scala.concurrent.duration.FiniteDuration
 
 case class EdgeConfig(
-    dynamic: DynamicEdgeConfig,
-    static: StaticEdgeConfig
+    dynamic: EdgeDynamicConfig,
+    static: EdgeStaticConfig
 ) derives ConfigReader:
   def toJson: String =
     given ConfigWriter[EdgeConfig] = deriveWriter

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeDynamicConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeDynamicConfig.scala
@@ -5,12 +5,12 @@ package arktwin.edge.configs
 import cats.data.ValidatedNec
 
 case class EdgeDynamicConfig(
-    coordinate: CoordinateConfig,
-    culling: CullingConfig
+    chart: ChartConfig,
+    coordinate: CoordinateConfig
 ):
   def validated(path: String): ValidatedNec[String, EdgeDynamicConfig] =
     import cats.syntax.apply.*
     (
-      coordinate.validated(s"$path.coordinate"),
-      culling.validated(s"$path.culling")
+      chart.validated(s"$path.chart"),
+      coordinate.validated(s"$path.coordinate")
     ).mapN(EdgeDynamicConfig.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeDynamicConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeDynamicConfig.scala
@@ -4,13 +4,13 @@ package arktwin.edge.configs
 
 import cats.data.ValidatedNec
 
-case class DynamicEdgeConfig(
+case class EdgeDynamicConfig(
     coordinate: CoordinateConfig,
     culling: CullingConfig
 ):
-  def validated(path: String): ValidatedNec[String, DynamicEdgeConfig] =
+  def validated(path: String): ValidatedNec[String, EdgeDynamicConfig] =
     import cats.syntax.apply.*
     (
       coordinate.validated(s"$path.coordinate"),
       culling.validated(s"$path.culling")
-    ).mapN(DynamicEdgeConfig.apply)
+    ).mapN(EdgeDynamicConfig.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeStaticConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeStaticConfig.scala
@@ -10,7 +10,7 @@ import scalapb.validate.{Failure, Success, Validator}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-case class StaticEdgeConfig(
+case class EdgeStaticConfig(
     actorMachineTimeout: FiniteDuration,
     clockInitialStashSize: Int,
     edgeIdPrefix: String,
@@ -25,7 +25,7 @@ case class StaticEdgeConfig(
     publishBatchSize: Int,
     publishBufferSize: Int
 ):
-  def validated(path: String): ValidatedNec[String, StaticEdgeConfig] =
+  def validated(path: String): ValidatedNec[String, EdgeStaticConfig] =
     import cats.syntax.apply.*
     (
       condNec(
@@ -80,4 +80,4 @@ case class StaticEdgeConfig(
         publishBufferSize,
         s"$path.publishBufferSize must be > 0"
       )
-    ).mapN(StaticEdgeConfig.apply)
+    ).mapN(EdgeStaticConfig.apply)

--- a/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeStaticConfig.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/configs/EdgeStaticConfig.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 case class EdgeStaticConfig(
     actorMachineTimeout: FiniteDuration,
-    clockInitialStashSize: Int,
     edgeIdPrefix: String,
     endpointMachineTimeout: FiniteDuration,
     host: String,
@@ -32,11 +31,6 @@ case class EdgeStaticConfig(
         actorMachineTimeout > 0.second,
         actorMachineTimeout,
         s"$path.actorMachineTimeout must be > 0"
-      ),
-      condNec(
-        clockInitialStashSize > 0,
-        clockInitialStashSize,
-        s"$path.clockInitialStashSize must be > 0"
       ),
       Validator[CreateEdgeRequest].validate(CreateEdgeRequest(edgeIdPrefix)) match
         case Success             => valid(edgeIdPrefix)

--- a/arktwin/edge/src/main/scala/arktwin/edge/connectors/ChartConnector.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/connectors/ChartConnector.scala
@@ -9,7 +9,7 @@ import arktwin.common.util.CommonMessages.Nop
 import arktwin.common.util.GrpcHeaderKeys
 import arktwin.common.util.SourceExtensions.*
 import arktwin.edge.actors.sinks.Chart
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.util.EdgeKamon
 import com.google.protobuf.empty.Empty
 import org.apache.pekko.actor.typed.ActorRef
@@ -19,7 +19,7 @@ import org.apache.pekko.stream.{Materializer, OverflowStrategy}
 // TODO retry connection in actor?
 case class ChartConnector(
     client: ChartClient,
-    staticConfig: StaticEdgeConfig,
+    staticConfig: EdgeStaticConfig,
     edgeId: String,
     kamon: EdgeKamon
 )(using

--- a/arktwin/edge/src/main/scala/arktwin/edge/connectors/RegisterConnector.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/connectors/RegisterConnector.scala
@@ -7,7 +7,7 @@ import arktwin.common.util.CommonMessages.Nop
 import arktwin.common.util.GrpcHeaderKeys
 import arktwin.common.util.SourceExtensions.*
 import arktwin.edge.actors.sinks.Register
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import com.google.protobuf.empty.Empty
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.stream.typed.scaladsl.{ActorSink, ActorSource}
@@ -16,7 +16,7 @@ import org.apache.pekko.stream.{Materializer, OverflowStrategy}
 // TODO retry connect in actor?
 case class RegisterConnector(
     client: RegisterClient,
-    staticConfig: StaticEdgeConfig,
+    staticConfig: EdgeStaticConfig,
     edgeId: String
 )(using
     Materializer

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeAgentsPut.scala
@@ -6,7 +6,7 @@ import arktwin.common.data.{TaggedTimestamp, VirtualTimestamp}
 import arktwin.common.util.JsonDerivation
 import arktwin.common.util.JsonDerivation.given
 import arktwin.edge.actors.adapters.EdgeAgentsPutAdapter
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.data.*
 import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
@@ -92,7 +92,7 @@ object EdgeAgentsPut:
 
   def route(
       adapter: ActorRef[EdgeAgentsPutAdapter.Message],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       kamon: EdgeKamon
   )(using
       ExecutionContext,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeBulk.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeBulk.scala
@@ -6,7 +6,7 @@ import arktwin.common.data.TaggedTimestamp
 import arktwin.common.util.JsonDerivation
 import arktwin.common.util.JsonDerivation.given
 import arktwin.edge.actors.adapters.{EdgeAgentsPutAdapter, EdgeNeighborsQueryAdapter}
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.data.*
 import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.ErrorStatus.InternalServerError
@@ -63,7 +63,7 @@ object EdgeBulk:
   def route(
       agentsPutAdapter: ActorRef[EdgeAgentsPutAdapter.Message],
       neighborsQueryAdapter: ActorRef[EdgeNeighborsQueryAdapter.Message],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       kamon: EdgeKamon
   )(using
       ExecutionContext,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
@@ -21,6 +21,7 @@ import sttp.tapir.*
 import sttp.tapir.json.jsoniter.jsonBody
 import sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 object EdgeConfigChartPut:
@@ -30,8 +31,11 @@ object EdgeConfigChartPut:
   given JsonValueCodec[Request] = JsonDerivation.makeCodec
 
   val inExample: Request = Request(
-    edgeCulling = true,
-    maxFirstAgents = 9
+    culling = true,
+    cullingMaxFirstAgents = 9,
+    expiration = false,
+    expirationCheckMachineInterval = 1.second,
+    expirationTimeout = 3.seconds
   )
 
   val endpoint: PublicEndpoint[Request, ErrorStatus, Response, Any] =

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
@@ -6,8 +6,8 @@ import arktwin.common.data.TaggedTimestamp
 import arktwin.common.util.JsonDerivation
 import arktwin.common.util.JsonDerivation.given
 import arktwin.edge.actors.EdgeConfigurator
-import arktwin.edge.actors.EdgeConfigurator.UpdateCullingConfig
-import arktwin.edge.configs.CullingConfig
+import arktwin.edge.actors.EdgeConfigurator.UpdateChartConfig
+import arktwin.edge.configs.ChartConfig
 import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.ErrorStatus.BadRequest
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
@@ -23,10 +23,10 @@ import sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object EdgeConfigCullingPut:
-  type Request = CullingConfig
+object EdgeConfigChartPut:
+  type Request = ChartConfig
   type Response = Unit
-  val Request: CullingConfig.type = CullingConfig
+  val Request: ChartConfig.type = ChartConfig
   given JsonValueCodec[Request] = JsonDerivation.makeCodec
 
   val inExample: Request = Request(
@@ -36,7 +36,7 @@ object EdgeConfigCullingPut:
 
   val endpoint: PublicEndpoint[Request, ErrorStatus, Response, Any] =
     tapir.endpoint.put
-      .in("api" / "edge" / "config" / "culling")
+      .in("api" / "edge" / "config" / "chart")
       .in(jsonBody[Request].example(inExample))
       .out(statusCode(Accepted))
       .errorOut(
@@ -59,7 +59,7 @@ object EdgeConfigCullingPut:
           case Invalid(errors) =>
             Future.successful(Left(BadRequest(errors.toChain.toVector)))
           case Valid(request) =>
-            configurator ! UpdateCullingConfig(request)
+            configurator ! UpdateChartConfig(request)
             Future.successful(Right(()))
         ).andThen: _ =>
           requestNumCounter.increment()

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigChartPut.scala
@@ -31,11 +31,15 @@ object EdgeConfigChartPut:
   given JsonValueCodec[Request] = JsonDerivation.makeCodec
 
   val inExample: Request = Request(
-    culling = true,
-    cullingMaxFirstAgents = 9,
-    expiration = false,
-    expirationCheckMachineInterval = 1.second,
-    expirationTimeout = 3.seconds
+    culling = Request.Culling(
+      enabled = true,
+      maxFirstAgents = 9
+    ),
+    expiration = Request.Expiration(
+      enabled = false,
+      checkMachineInterval = 1.second,
+      timeout = 3.seconds
+    )
   )
 
   val endpoint: PublicEndpoint[Request, ErrorStatus, Response, Any] =

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -7,7 +7,7 @@ import arktwin.common.util.JsonDerivation
 import arktwin.common.util.JsonDerivation.given
 import arktwin.common.util.LoggerConfigurator.LogLevel
 import arktwin.edge.actors.EdgeConfigurator
-import arktwin.edge.configs.{DynamicEdgeConfig, EdgeConfig, StaticEdgeConfig}
+import arktwin.edge.configs.{EdgeConfig, EdgeDynamicConfig, EdgeStaticConfig}
 import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
@@ -30,11 +30,11 @@ object EdgeConfigGet:
   given JsonValueCodec[Response] = JsonDerivation.makeCodec
 
   val outExample: Response = Response(
-    dynamic = DynamicEdgeConfig(
+    dynamic = EdgeDynamicConfig(
       coordinate = EdgeConfigCoordinatePut.inExample,
       culling = EdgeConfigCullingPut.inExample
     ),
-    static = StaticEdgeConfig(
+    static = EdgeStaticConfig(
       actorMachineTimeout = 90.milliseconds,
       clockInitialStashSize = 100,
       edgeIdPrefix = "edge",
@@ -63,7 +63,7 @@ object EdgeConfigGet:
 
   def route(
       configurator: ActorRef[EdgeConfigurator.Message],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       kamon: EdgeKamon
   )(using
       ExecutionContext,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -31,8 +31,8 @@ object EdgeConfigGet:
 
   val outExample: Response = Response(
     dynamic = EdgeDynamicConfig(
-      coordinate = EdgeConfigCoordinatePut.inExample,
-      culling = EdgeConfigCullingPut.inExample
+      chart = EdgeConfigChartPut.inExample,
+      coordinate = EdgeConfigCoordinatePut.inExample
     ),
     static = EdgeStaticConfig(
       actorMachineTimeout = 90.milliseconds,

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeConfigGet.scala
@@ -36,7 +36,6 @@ object EdgeConfigGet:
     ),
     static = EdgeStaticConfig(
       actorMachineTimeout = 90.milliseconds,
-      clockInitialStashSize = 100,
       edgeIdPrefix = "edge",
       endpointMachineTimeout = 100.milliseconds,
       host = "0.0.0.0",

--- a/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
+++ b/arktwin/edge/src/main/scala/arktwin/edge/endpoints/EdgeNeighborsQuery.scala
@@ -6,7 +6,7 @@ import arktwin.common.data.{TaggedTimestamp, VirtualTimestamp}
 import arktwin.common.util.JsonDerivation
 import arktwin.common.util.JsonDerivation.given
 import arktwin.edge.actors.adapters.EdgeNeighborsQueryAdapter
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.data.*
 import arktwin.edge.util.EndpointExtensions.serverLogicWithLog
 import arktwin.edge.util.{EdgeKamon, ErrorStatus}
@@ -75,7 +75,7 @@ object EdgeNeighborsQuery:
 
   def route(
       adapter: ActorRef[EdgeNeighborsQueryAdapter.Message],
-      staticConfig: StaticEdgeConfig,
+      staticConfig: EdgeStaticConfig,
       kamon: EdgeKamon
   )(using
       ExecutionContext,

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -20,8 +20,11 @@ class EdgeConfiguratorSpec extends ActorTestBase:
   private val baseConfig = EdgeConfig(
     dynamic = EdgeDynamicConfig(
       chart = ChartConfig(
-        edgeCulling = true,
-        maxFirstAgents = 9
+        culling = true,
+        cullingMaxFirstAgents = 9,
+        expiration = false,
+        expirationCheckMachineInterval = 1.second,
+        expirationTimeout = 3.seconds
       ),
       coordinate = CoordinateConfig(
         axis = AxisConfig(
@@ -84,7 +87,7 @@ class EdgeConfiguratorSpec extends ActorTestBase:
         Using(ActorTestKit()): testKit =>
           val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
-          val newChartConfig = baseConfig.dynamic.chart.copy(maxFirstAgents = 999)
+          val newChartConfig = baseConfig.dynamic.chart.copy(cullingMaxFirstAgents = 999)
 
           configurator ! UpdateChartConfig(newChartConfig)
           configurator ! Read(reader.ref)
@@ -125,7 +128,7 @@ class EdgeConfiguratorSpec extends ActorTestBase:
           assert(observer1.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
           assert(observer2.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
 
-          val newConfig = baseConfig.dynamic.chart.copy(maxFirstAgents = 456)
+          val newConfig = baseConfig.dynamic.chart.copy(cullingMaxFirstAgents = 456)
           configurator ! UpdateChartConfig(newConfig)
 
           assert(observer1.receiveMessage() == UpdateChartConfig(newConfig))

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -20,11 +20,15 @@ class EdgeConfiguratorSpec extends ActorTestBase:
   private val baseConfig = EdgeConfig(
     dynamic = EdgeDynamicConfig(
       chart = ChartConfig(
-        culling = true,
-        cullingMaxFirstAgents = 9,
-        expiration = false,
-        expirationCheckMachineInterval = 1.second,
-        expirationTimeout = 3.seconds
+        culling = ChartConfig.Culling(
+          enabled = true,
+          maxFirstAgents = 9
+        ),
+        expiration = ChartConfig.Expiration(
+          enabled = false,
+          checkMachineInterval = 1.second,
+          timeout = 3.seconds
+        )
       ),
       coordinate = CoordinateConfig(
         axis = AxisConfig(
@@ -86,7 +90,8 @@ class EdgeConfiguratorSpec extends ActorTestBase:
         Using(ActorTestKit()): testKit =>
           val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
-          val newChartConfig = baseConfig.dynamic.chart.copy(cullingMaxFirstAgents = 999)
+          val newChartConfig = baseConfig.dynamic.chart
+            .copy(culling = baseConfig.dynamic.chart.culling.copy(maxFirstAgents = 999))
 
           configurator ! UpdateChartConfig(newChartConfig)
           configurator ! Read(reader.ref)
@@ -127,7 +132,8 @@ class EdgeConfiguratorSpec extends ActorTestBase:
           assert(observer1.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
           assert(observer2.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
 
-          val newConfig = baseConfig.dynamic.chart.copy(cullingMaxFirstAgents = 456)
+          val newConfig = baseConfig.dynamic.chart
+            .copy(culling = baseConfig.dynamic.chart.culling.copy(maxFirstAgents = 456))
           configurator ! UpdateChartConfig(newConfig)
 
           assert(observer1.receiveMessage() == UpdateChartConfig(newConfig))

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -18,7 +18,7 @@ import scala.util.Using
 
 class EdgeConfiguratorSpec extends ActorTestBase:
   private val baseConfig = EdgeConfig(
-    dynamic = DynamicEdgeConfig(
+    dynamic = EdgeDynamicConfig(
       coordinate = CoordinateConfig(
         axis = AxisConfig(
           xDirection = Direction.East,
@@ -39,7 +39,7 @@ class EdgeConfiguratorSpec extends ActorTestBase:
         maxFirstAgents = 9
       )
     ),
-    static = StaticEdgeConfig(
+    static = EdgeStaticConfig(
       actorMachineTimeout = 90.milliseconds,
       clockInitialStashSize = 100,
       edgeIdPrefix = "edge",

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -19,6 +19,10 @@ import scala.util.Using
 class EdgeConfiguratorSpec extends ActorTestBase:
   private val baseConfig = EdgeConfig(
     dynamic = EdgeDynamicConfig(
+      chart = ChartConfig(
+        edgeCulling = true,
+        maxFirstAgents = 9
+      ),
       coordinate = CoordinateConfig(
         axis = AxisConfig(
           xDirection = Direction.East,
@@ -33,10 +37,6 @@ class EdgeConfiguratorSpec extends ActorTestBase:
         ),
         lengthUnit = LengthUnit.Meter,
         speedUnit = SpeedUnit.MeterPerSecond
-      ),
-      culling = CullingConfig(
-        edgeCulling = true,
-        maxFirstAgents = 9
       )
     ),
     static = EdgeStaticConfig(
@@ -78,20 +78,20 @@ class EdgeConfiguratorSpec extends ActorTestBase:
 
           val receivedConfig = reader.receiveMessage()
           assert(receivedConfig.dynamic.coordinate == newCoordinateConfig)
-          assert(receivedConfig.dynamic.culling == baseConfig.dynamic.culling)
+          assert(receivedConfig.dynamic.chart == baseConfig.dynamic.chart)
 
-      it("replies updated configuration after culling config update"):
+      it("replies updated configuration after chart config update"):
         Using(ActorTestKit()): testKit =>
           val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
           val reader = testKit.createTestProbe[EdgeConfig]()
-          val newCullingConfig = baseConfig.dynamic.culling.copy(maxFirstAgents = 999)
+          val newChartConfig = baseConfig.dynamic.chart.copy(maxFirstAgents = 999)
 
-          configurator ! UpdateCullingConfig(newCullingConfig)
+          configurator ! UpdateChartConfig(newChartConfig)
           configurator ! Read(reader.ref)
 
           val receivedConfig = reader.receiveMessage()
           assert(receivedConfig.dynamic.coordinate == baseConfig.dynamic.coordinate)
-          assert(receivedConfig.dynamic.culling == newCullingConfig)
+          assert(receivedConfig.dynamic.chart == newChartConfig)
 
     describe("UpdateCoordinateConfig"):
       it("distributes coordinate configuration to registered coordinate observers"):
@@ -112,21 +112,21 @@ class EdgeConfiguratorSpec extends ActorTestBase:
           assert(observer1.receiveMessage().config == newConfig)
           assert(observer2.receiveMessage().config == newConfig)
 
-    describe("UpdateCullingConfig"):
-      it("distributes culling configuration to registered culling observers"):
+    describe("UpdateChartConfig"):
+      it("distributes chart configuration to registered chart observers"):
         Using(ActorTestKit()): testKit =>
           val configurator = testKit.spawn(EdgeConfigurator(baseConfig))
-          val observer1 = testKit.createTestProbe[UpdateCullingConfig]()
-          val observer2 = testKit.createTestProbe[UpdateCullingConfig]()
+          val observer1 = testKit.createTestProbe[UpdateChartConfig]()
+          val observer2 = testKit.createTestProbe[UpdateChartConfig]()
 
-          testKit.system.receptionist ! Receptionist.register(cullingObserverKey, observer1.ref)
-          testKit.system.receptionist ! Receptionist.register(cullingObserverKey, observer2.ref)
+          testKit.system.receptionist ! Receptionist.register(chartObserverKey, observer1.ref)
+          testKit.system.receptionist ! Receptionist.register(chartObserverKey, observer2.ref)
 
-          assert(observer1.receiveMessage() == UpdateCullingConfig(baseConfig.dynamic.culling))
-          assert(observer2.receiveMessage() == UpdateCullingConfig(baseConfig.dynamic.culling))
+          assert(observer1.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
+          assert(observer2.receiveMessage() == UpdateChartConfig(baseConfig.dynamic.chart))
 
-          val newConfig = baseConfig.dynamic.culling.copy(maxFirstAgents = 456)
-          configurator ! UpdateCullingConfig(newConfig)
+          val newConfig = baseConfig.dynamic.chart.copy(maxFirstAgents = 456)
+          configurator ! UpdateChartConfig(newConfig)
 
-          assert(observer1.receiveMessage() == UpdateCullingConfig(newConfig))
-          assert(observer2.receiveMessage() == UpdateCullingConfig(newConfig))
+          assert(observer1.receiveMessage() == UpdateChartConfig(newConfig))
+          assert(observer2.receiveMessage() == UpdateChartConfig(newConfig))

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/EdgeConfiguratorSpec.scala
@@ -44,7 +44,6 @@ class EdgeConfiguratorSpec extends ActorTestBase:
     ),
     static = EdgeStaticConfig(
       actorMachineTimeout = 90.milliseconds,
-      clockInitialStashSize = 100,
       edgeIdPrefix = "edge",
       endpointMachineTimeout = 100.milliseconds,
       host = "0.0.0.0",

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
@@ -2,15 +2,18 @@
 // Copyright 2024-2025 TOYOTA MOTOR CORPORATION
 package arktwin.edge.actors.sinks
 
-import arktwin.center.services.ChartAgent
+import arktwin.center.services.{ChartAgent, ClockBase}
 import arktwin.common.data.*
 import arktwin.edge.actors.EdgeConfigurator.UpdateChartConfig
 import arktwin.edge.actors.sinks.Chart.*
+import arktwin.edge.actors.sinks.Clock.UpdateClockBase
 import arktwin.edge.configs.ChartConfig
 import arktwin.edge.test.ActorTestBase
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.scalactic.{Equality, TolerantNumerics}
 
 import scala.concurrent.duration.DurationInt
+import scala.util.Using
 
 class ChartSpec extends ActorTestBase:
   private given Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.001)
@@ -23,12 +26,18 @@ class ChartSpec extends ActorTestBase:
     case _ =>
       false
 
+  private val initClockBase = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
+
   private val baseConfig = ChartConfig(
-    culling = true,
-    cullingMaxFirstAgents = 9,
-    expiration = false,
-    expirationCheckMachineInterval = 1.second,
-    expirationTimeout = 3.seconds
+    culling = ChartConfig.Culling(
+      enabled = true,
+      maxFirstAgents = 9
+    ),
+    expiration = ChartConfig.Expiration(
+      enabled = false,
+      checkMachineInterval = 1.second,
+      timeout = 3.seconds
+    )
   )
 
   private def chartAgent(
@@ -50,223 +59,404 @@ class ChartSpec extends ActorTestBase:
     )
 
   describe("Chart"):
+    describe("DeleteExpiredNeighbors"):
+      it("deletes expired neighbors when expiration is enabled"):
+        Using(ActorTestKit()): testKit =>
+          val expirationConfig = baseConfig.copy(
+            expiration = ChartConfig.Expiration(
+              enabled = true,
+              checkMachineInterval = 100.milliseconds,
+              timeout = 2.seconds
+            )
+          )
+          val initClockBase = ClockBase(
+            TaggedTimestamp.machineNow().untag,
+            Timestamp(0, 0),
+            1.0
+          )
+          val chart = testKit.spawn(Chart(initClockBase, expirationConfig))
+          val clock = testKit.spawn(Clock(initClockBase))
+          val reader = testKit.createTestProbe[ReadReply]()
+
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-2", Timestamp(0, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-3", Timestamp(0, 0), Vector3Enu(3, 3, 3)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
+            )
+          }
+
+          clock ! UpdateClockBase(
+            ClockBase(
+              TaggedTimestamp.machineNow().untag,
+              Timestamp(10, 0),
+              1.0
+            )
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(7, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-2", Timestamp(9, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-3", Timestamp(10, 0), Vector3Enu(3, 3, 3)))
+          Thread.sleep(expirationConfig.expiration.checkMachineInterval.toMillis * 2)
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-2", "agent-3")
+            )
+          }
+
+      it("does not delete neighbors when expiration is disabled"):
+        Using(ActorTestKit()): testKit =>
+          val expirationConfig = baseConfig.copy(
+            expiration = ChartConfig.Expiration(
+              enabled = false,
+              checkMachineInterval = 100.milliseconds,
+              timeout = 2.seconds
+            )
+          )
+          val initClockBase = ClockBase(
+            TaggedTimestamp.machineNow().untag,
+            Timestamp(0, 0),
+            1.0
+          )
+          val chart = testKit.spawn(Chart(initClockBase, expirationConfig))
+          val clock = testKit.spawn(Clock(initClockBase))
+          val reader = testKit.createTestProbe[ReadReply]()
+
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-2", Timestamp(0, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-3", Timestamp(0, 0), Vector3Enu(3, 3, 3)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
+            )
+          }
+
+          clock ! UpdateClockBase(
+            ClockBase(
+              TaggedTimestamp.machineNow().untag,
+              Timestamp(10, 0),
+              1.0
+            )
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(7, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-2", Timestamp(9, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-3", Timestamp(10, 0), Vector3Enu(3, 3, 3)))
+          Thread.sleep(expirationConfig.expiration.checkMachineInterval.toMillis * 2)
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
+            )
+          }
+
     describe("Read"):
       it("replies empty sequence when no agents are registered"):
-        val chart = testKit.spawn(Chart(baseConfig))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(Chart(initClockBase, baseConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! Read(reader.ref)
+          chart ! Read(reader.ref)
 
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(orderedNeighbors == Seq())
+          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+          assert(orderedNeighbors == Seq())
 
     describe("UpdateChartConfig"):
-      it("updates chart configuration dynamically"):
-        val chart = testKit.spawn(Chart(baseConfig.copy(culling = false)))
-        val reader = testKit.createTestProbe[ReadReply]()
+      it("updates chart culling configuration dynamically"):
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(
+            Chart(
+              initClockBase,
+              baseConfig.copy(culling = ChartConfig.Culling(enabled = false, maxFirstAgents = 0))
+            )
+          )
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! UpdateFirstAgents(Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0))))
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(3, 4, 0)))
-        chart ! Read(reader.ref)
-        {
-          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-          assert(orderedNeighbors.size == 1)
-          assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
-          assert(orderedNeighbors(0).nearestDistance == None)
-        }
+          chart ! UpdateFirstAgents(
+            Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)))
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(3, 4, 0)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1)
+            assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
+            assert(orderedNeighbors(0).nearestDistance == None)
+          }
 
-        chart ! UpdateChartConfig(baseConfig.copy(culling = true, cullingMaxFirstAgents = 10))
-        chart ! UpdateFirstAgents(Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0))))
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(3, 4, 0)))
-        chart ! Read(reader.ref)
-        {
-          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-          assert(orderedNeighbors.size == 1)
-          assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
-          assert(orderedNeighbors(0).nearestDistance === Some(5.0))
-        }
+          chart ! UpdateChartConfig(
+            baseConfig.copy(culling = ChartConfig.Culling(enabled = true, maxFirstAgents = 10))
+          )
+          chart ! UpdateFirstAgents(
+            Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)))
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(3, 4, 0)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1)
+            assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
+            assert(orderedNeighbors(0).nearestDistance === Some(5.0))
+          }
+
+      it("updates chart expiration configuration dynamically"):
+        Using(ActorTestKit()): testKit =>
+          val expirationConfig = baseConfig.copy(
+            expiration = ChartConfig.Expiration(
+              enabled = false,
+              checkMachineInterval = 100.milliseconds,
+              timeout = 1.day
+            )
+          )
+          val initClockBase = ClockBase(
+            TaggedTimestamp.machineNow().untag,
+            Timestamp(123, 0),
+            1.0
+          )
+          val chart = testKit.spawn(Chart(initClockBase, expirationConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(122, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-2", Timestamp(121, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-3", Timestamp(100, 0), Vector3Enu(3, 3, 3)))
+          Thread.sleep(expirationConfig.expiration.checkMachineInterval.toMillis * 2)
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
+            )
+          }
+
+          val newExpirationConfig = baseConfig.copy(
+            expiration = ChartConfig.Expiration(
+              enabled = true,
+              checkMachineInterval = 100.milliseconds,
+              timeout = 10.seconds
+            )
+          )
+          chart ! UpdateChartConfig(newExpirationConfig)
+          Thread.sleep(newExpirationConfig.expiration.checkMachineInterval.toMillis * 2)
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2")
+            )
+          }
 
     describe("UpdateFirstAgents"):
       it("updates first agents when culling is enabled"):
-        val chart =
-          testKit.spawn(Chart(baseConfig.copy(culling = true, cullingMaxFirstAgents = 10)))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart =
+            testKit.spawn(
+              Chart(
+                initClockBase,
+                baseConfig.copy(culling = ChartConfig.Culling(enabled = true, maxFirstAgents = 10))
+              )
+            )
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! UpdateFirstAgents(
-          Seq(
-            chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)),
-            chartAgent("first-2", Timestamp(0, 0), Vector3Enu(5, 5, 5))
+          chart ! UpdateFirstAgents(
+            Seq(
+              chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)),
+              chartAgent("first-2", Timestamp(0, 0), Vector3Enu(5, 5, 5))
+            )
           )
-        )
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
-        chart ! Read(reader.ref)
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
+          chart ! Read(reader.ref)
 
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(orderedNeighbors.size == 1)
-        assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
-        assert(orderedNeighbors(0).nearestDistance === Some(1.0)) // (0,0,0) to (1,0,0)
-
-      it("ignores first agents when culling is disabled"):
-        val chart = testKit.spawn(Chart(baseConfig.copy(culling = false)))
-        val reader = testKit.createTestProbe[ReadReply]()
-
-        chart ! UpdateFirstAgents(
-          Seq(
-            chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)),
-            chartAgent("first-2", Timestamp(0, 0), Vector3Enu(5, 5, 5))
-          )
-        )
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
-        chart ! Read(reader.ref)
-
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(orderedNeighbors.size == 1)
-        assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
-        assert(orderedNeighbors(0).nearestDistance == None)
-
-      it("ignores first agents when exceeding cullingMaxFirstAgents"):
-        val chart = testKit.spawn(Chart(baseConfig.copy(culling = true, cullingMaxFirstAgents = 2)))
-        val reader = testKit.createTestProbe[ReadReply]()
-
-        chart ! UpdateFirstAgents(
-          Seq(
-            chartAgent("first-1", Timestamp(0, 0), Vector3Enu(1, 1, 1))
-          )
-        )
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
-        chart ! Read(reader.ref)
-        {
           val orderedNeighbors = reader.receiveMessage().orderedNeighbors
           assert(orderedNeighbors.size == 1)
           assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
-          assert(orderedNeighbors(0).nearestDistance == Some(math.sqrt(2)))
-        }
+          assert(orderedNeighbors(0).nearestDistance === Some(1.0)) // (0,0,0) to (1,0,0)
 
-        chart ! UpdateFirstAgents(
-          Seq(
-            chartAgent("first-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)),
-            chartAgent("first-2", Timestamp(0, 0), Vector3Enu(2, 2, 2)),
-            chartAgent("first-3", Timestamp(0, 0), Vector3Enu(3, 3, 3))
+      it("ignores first agents when culling is disabled"):
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(
+            Chart(
+              initClockBase,
+              baseConfig.copy(culling = ChartConfig.Culling(enabled = false, maxFirstAgents = 0))
+            )
           )
-        )
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 1), Vector3Enu(1, 0, 0)))
-        chart ! Read(reader.ref)
-        {
+          val reader = testKit.createTestProbe[ReadReply]()
+
+          chart ! UpdateFirstAgents(
+            Seq(
+              chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0)),
+              chartAgent("first-2", Timestamp(0, 0), Vector3Enu(5, 5, 5))
+            )
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
+          chart ! Read(reader.ref)
+
           val orderedNeighbors = reader.receiveMessage().orderedNeighbors
           assert(orderedNeighbors.size == 1)
           assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
           assert(orderedNeighbors(0).nearestDistance == None)
-        }
+
+      it("ignores first agents when exceeding cullingMaxFirstAgents"):
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(
+            Chart(
+              initClockBase,
+              baseConfig.copy(culling = ChartConfig.Culling(enabled = true, maxFirstAgents = 2))
+            )
+          )
+          val reader = testKit.createTestProbe[ReadReply]()
+
+          chart ! UpdateFirstAgents(
+            Seq(
+              chartAgent("first-1", Timestamp(0, 0), Vector3Enu(1, 1, 1))
+            )
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 0, 0)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1)
+            assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
+            assert(orderedNeighbors(0).nearestDistance == Some(math.sqrt(2)))
+          }
+
+          chart ! UpdateFirstAgents(
+            Seq(
+              chartAgent("first-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)),
+              chartAgent("first-2", Timestamp(0, 0), Vector3Enu(2, 2, 2)),
+              chartAgent("first-3", Timestamp(0, 0), Vector3Enu(3, 3, 3))
+            )
+          )
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 1), Vector3Enu(1, 0, 0)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1)
+            assert(orderedNeighbors(0).neighbor.agentId == "agent-1")
+            assert(orderedNeighbors(0).nearestDistance == None)
+          }
 
     describe("UpdateNeighbor"):
       it("adds new agents"):
-        val chart = testKit.spawn(Chart(baseConfig))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(Chart(initClockBase, baseConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        for i <- 1 to 3 do
-          chart ! UpdateNeighbor(chartAgent(s"agent-$i", Timestamp(0, 0), Vector3Enu(i, i, i)))
-        chart ! Read(reader.ref)
+          for i <- 1 to 3 do
+            chart ! UpdateNeighbor(chartAgent(s"agent-$i", Timestamp(0, 0), Vector3Enu(i, i, i)))
+          chart ! Read(reader.ref)
 
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(
-          orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
-        )
-        assert(orderedNeighbors.forall(_.nearestDistance == None))
+          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+          assert(
+            orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1", "agent-2", "agent-3")
+          )
+          assert(orderedNeighbors.forall(_.nearestDistance == None))
 
       it("updates existing agents with newer timestamp"):
-        val chart = testKit.spawn(Chart(baseConfig))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(Chart(initClockBase, baseConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)))
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(2, 2, 2)))
-        chart ! Read(reader.ref)
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)))
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(2, 2, 2)))
+          chart ! Read(reader.ref)
 
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1"))
-        assert(orderedNeighbors(0).neighbor.transform.timestamp == Timestamp(1, 0))
-        assert(orderedNeighbors(0).neighbor.transform.localTranslationMeter == Vector3Enu(2, 2, 2))
-        assert(orderedNeighbors(0).nearestDistance == None)
+          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+          assert(orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1"))
+          assert(orderedNeighbors(0).neighbor.transform.timestamp == Timestamp(1, 0))
+          assert(
+            orderedNeighbors(0).neighbor.transform.localTranslationMeter == Vector3Enu(2, 2, 2)
+          )
+          assert(orderedNeighbors(0).nearestDistance == None)
 
       it("ignores existing agents with older timestamp"):
-        val chart = testKit.spawn(Chart(baseConfig))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(Chart(initClockBase, baseConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(2, 0), Vector3Enu(2, 2, 2)))
-        chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(1, 1, 1)))
-        chart ! Read(reader.ref)
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(2, 0), Vector3Enu(2, 2, 2)))
+          chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(1, 1, 1)))
+          chart ! Read(reader.ref)
 
-        val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-        assert(orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1"))
-        assert(orderedNeighbors(0).neighbor.transform.localTranslationMeter == Vector3Enu(2, 2, 2))
-        assert(orderedNeighbors(0).neighbor.transform.timestamp == Timestamp(2, 0))
-        assert(orderedNeighbors(0).nearestDistance == None)
+          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+          assert(orderedNeighbors.map(_.neighbor.agentId).toSet == Set("agent-1"))
+          assert(
+            orderedNeighbors(0).neighbor.transform.localTranslationMeter == Vector3Enu(2, 2, 2)
+          )
+          assert(orderedNeighbors(0).neighbor.transform.timestamp == Timestamp(2, 0))
+          assert(orderedNeighbors(0).nearestDistance == None)
 
       it("sorts neighbors by distance from nearest first agent"):
-        val chart = testKit.spawn(Chart(baseConfig))
-        val reader = testKit.createTestProbe[ReadReply]()
+        Using(ActorTestKit()): testKit =>
+          val chart = testKit.spawn(Chart(initClockBase, baseConfig))
+          val reader = testKit.createTestProbe[ReadReply]()
 
-        chart ! UpdateFirstAgents(
-          Seq(
-            chartAgent("a0", Timestamp(0, 0), Vector3Enu(1.99, 2.98, 3.97)), // near b-2-3-4
-            chartAgent("a1", Timestamp(0, 0), Vector3Enu(8.80, 7.81, 6.82)) // near b-9-8-7
-          )
-        )
-        for
-          x <- 0 to 9
-          y <- 0 to 9
-          z <- 0 to 9
-        do chart ! UpdateNeighbor(chartAgent(s"b-$x-$y-$z", Timestamp(1, 0), Vector3Enu(x, y, z)))
-        chart ! Read(reader.ref)
-        {
-          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-          assert(orderedNeighbors.size == 1000)
-          assert(
-            orderedNeighbors.map(_.neighbor.agentId).take(9) == Seq(
-              "b-2-3-4",
-              "b-9-8-7",
-              "b-8-8-7",
-              "b-9-7-7",
-              "b-9-8-6",
-              "b-2-3-3",
-              "b-2-2-4",
-              "b-1-3-4",
-              "b-3-3-4"
+          chart ! UpdateFirstAgents(
+            Seq(
+              chartAgent("a0", Timestamp(0, 0), Vector3Enu(1.99, 2.98, 3.97)), // near b-2-3-4
+              chartAgent("a1", Timestamp(0, 0), Vector3Enu(8.80, 7.81, 6.82)) // near b-9-8-7
             )
           )
-          assert(
-            orderedNeighbors(0).nearestDistance === Some(
-              math.sqrt(0.0014)
-            ) // (1.99, 2.98, 3.97) to (2, 3, 4)
-          )
-          assert(
-            orderedNeighbors(1).nearestDistance === Some(
-              math.sqrt(0.1085)
-            ) // (8.80, 7.81, 6.82) to (9, 8, 7)
-          )
-          assert(
-            orderedNeighbors(2).nearestDistance === Some(
-              math.sqrt(0.7085)
-            ) // (8.80, 7.81, 6.82) to (8, 8, 7)
-          )
-        }
-
-        for
-          x <- 0 to 9
-          y <- 0 to 9
-          z <- 0 to 9
-        do
-          chart ! UpdateNeighbor(
-            chartAgent(s"b-$x-$y-$z", Timestamp(1, 0), Vector3Enu(x * 0.1, y * 0.1, z * 0.1))
-          )
-        chart ! Read(reader.ref)
-        {
-          val orderedNeighbors = reader.receiveMessage().orderedNeighbors
-          assert(orderedNeighbors.size == 1000)
-          assert(
-            orderedNeighbors.map(_.neighbor.agentId).take(3) == Seq(
-              "b-9-9-9",
-              "b-8-9-9",
-              "b-9-8-9"
+          for
+            x <- 0 to 9
+            y <- 0 to 9
+            z <- 0 to 9
+          do chart ! UpdateNeighbor(chartAgent(s"b-$x-$y-$z", Timestamp(1, 0), Vector3Enu(x, y, z)))
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1000)
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).take(9) == Seq(
+                "b-2-3-4",
+                "b-9-8-7",
+                "b-8-8-7",
+                "b-9-7-7",
+                "b-9-8-6",
+                "b-2-3-3",
+                "b-2-2-4",
+                "b-1-3-4",
+                "b-3-3-4"
+              )
             )
-          )
-        }
+            assert(
+              orderedNeighbors(0).nearestDistance === Some(
+                math.sqrt(0.0014)
+              ) // (1.99, 2.98, 3.97) to (2, 3, 4)
+            )
+            assert(
+              orderedNeighbors(1).nearestDistance === Some(
+                math.sqrt(0.1085)
+              ) // (8.80, 7.81, 6.82) to (9, 8, 7)
+            )
+            assert(
+              orderedNeighbors(2).nearestDistance === Some(
+                math.sqrt(0.7085)
+              ) // (8.80, 7.81, 6.82) to (8, 8, 7)
+            )
+          }
+
+          for
+            x <- 0 to 9
+            y <- 0 to 9
+            z <- 0 to 9
+          do
+            chart ! UpdateNeighbor(
+              chartAgent(s"b-$x-$y-$z", Timestamp(1, 0), Vector3Enu(x * 0.1, y * 0.1, z * 0.1))
+            )
+          chart ! Read(reader.ref)
+          {
+            val orderedNeighbors = reader.receiveMessage().orderedNeighbors
+            assert(orderedNeighbors.size == 1000)
+            assert(
+              orderedNeighbors.map(_.neighbor.agentId).take(3) == Seq(
+                "b-9-9-9",
+                "b-8-9-9",
+                "b-9-8-9"
+              )
+            )
+          }

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ChartSpec.scala
@@ -4,9 +4,9 @@ package arktwin.edge.actors.sinks
 
 import arktwin.center.services.ChartAgent
 import arktwin.common.data.*
-import arktwin.edge.actors.EdgeConfigurator.UpdateCullingConfig
+import arktwin.edge.actors.EdgeConfigurator.UpdateChartConfig
 import arktwin.edge.actors.sinks.Chart.*
-import arktwin.edge.configs.CullingConfig
+import arktwin.edge.configs.ChartConfig
 import arktwin.edge.test.ActorTestBase
 import org.scalactic.{Equality, TolerantNumerics}
 
@@ -42,7 +42,7 @@ class ChartSpec extends ActorTestBase:
   describe("Chart"):
     describe("Read"):
       it("replies empty sequence when no agents are registered"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 1)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 1)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! Read(reader.ref)
@@ -50,9 +50,9 @@ class ChartSpec extends ActorTestBase:
         val orderedNeighbors = reader.receiveMessage().orderedNeighbors
         assert(orderedNeighbors == Seq())
 
-    describe("UpdateCullingConfig"):
-      it("updates culling configuration dynamically"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = false, maxFirstAgents = 0)))
+    describe("UpdateChartConfig"):
+      it("updates chart configuration dynamically"):
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = false, maxFirstAgents = 0)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateFirstAgents(Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0))))
@@ -65,7 +65,7 @@ class ChartSpec extends ActorTestBase:
           assert(orderedNeighbors(0).nearestDistance == None)
         }
 
-        chart ! UpdateCullingConfig(CullingConfig(edgeCulling = true, maxFirstAgents = 10))
+        chart ! UpdateChartConfig(ChartConfig(edgeCulling = true, maxFirstAgents = 10))
         chart ! UpdateFirstAgents(Seq(chartAgent("first-1", Timestamp(0, 0), Vector3Enu(0, 0, 0))))
         chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(1, 0), Vector3Enu(3, 4, 0)))
         chart ! Read(reader.ref)
@@ -78,7 +78,7 @@ class ChartSpec extends ActorTestBase:
 
     describe("UpdateFirstAgents"):
       it("updates first agents when culling is enabled"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 10)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 10)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateFirstAgents(
@@ -96,7 +96,7 @@ class ChartSpec extends ActorTestBase:
         assert(orderedNeighbors(0).nearestDistance === Some(1.0)) // (0,0,0) to (1,0,0)
 
       it("ignores first agents when culling is disabled"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = false, maxFirstAgents = 0)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = false, maxFirstAgents = 0)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateFirstAgents(
@@ -114,7 +114,7 @@ class ChartSpec extends ActorTestBase:
         assert(orderedNeighbors(0).nearestDistance == None)
 
       it("ignores first agents when exceeding maxFirstAgents"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 2)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 2)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateFirstAgents(
@@ -149,7 +149,7 @@ class ChartSpec extends ActorTestBase:
 
     describe("UpdateNeighbor"):
       it("adds new agents"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 1)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 1)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         for i <- 1 to 3 do
@@ -163,7 +163,7 @@ class ChartSpec extends ActorTestBase:
         assert(orderedNeighbors.forall(_.nearestDistance == None))
 
       it("updates existing agents with newer timestamp"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 1)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 1)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(0, 0), Vector3Enu(1, 1, 1)))
@@ -177,7 +177,7 @@ class ChartSpec extends ActorTestBase:
         assert(orderedNeighbors(0).nearestDistance == None)
 
       it("ignores existing agents with older timestamp"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 1)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 1)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateNeighbor(chartAgent("agent-1", Timestamp(2, 0), Vector3Enu(2, 2, 2)))
@@ -191,7 +191,7 @@ class ChartSpec extends ActorTestBase:
         assert(orderedNeighbors(0).nearestDistance == None)
 
       it("sorts neighbors by distance from nearest first agent"):
-        val chart = testKit.spawn(Chart(CullingConfig(edgeCulling = true, maxFirstAgents = 10)))
+        val chart = testKit.spawn(Chart(ChartConfig(edgeCulling = true, maxFirstAgents = 10)))
         val reader = testKit.createTestProbe[ReadReply]()
 
         chart ! UpdateFirstAgents(

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
@@ -6,7 +6,7 @@ import arktwin.center.services.ClockBase
 import arktwin.common.data.Timestamp
 import arktwin.common.util.LoggerConfigurator.LogLevel
 import arktwin.edge.actors.sinks.Clock.*
-import arktwin.edge.configs.StaticEdgeConfig
+import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.test.ActorTestBase
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.apache.pekko.actor.typed.receptionist.Receptionist
@@ -15,7 +15,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Using
 
 class ClockSpec extends ActorTestBase:
-  private val baseConfig = StaticEdgeConfig(
+  private val baseConfig = EdgeStaticConfig(
     actorMachineTimeout = 90.milliseconds,
     clockInitialStashSize = 100,
     edgeIdPrefix = "edge",

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
@@ -4,32 +4,14 @@ package arktwin.edge.actors.sinks
 
 import arktwin.center.services.ClockBase
 import arktwin.common.data.Timestamp
-import arktwin.common.util.LoggerConfigurator.LogLevel
 import arktwin.edge.actors.sinks.Clock.*
-import arktwin.edge.configs.EdgeStaticConfig
 import arktwin.edge.test.ActorTestBase
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import org.apache.pekko.actor.typed.receptionist.Receptionist
 
-import scala.concurrent.duration.DurationInt
 import scala.util.Using
 
 class ClockSpec extends ActorTestBase:
-  private val baseConfig = EdgeStaticConfig(
-    actorMachineTimeout = 90.milliseconds,
-    edgeIdPrefix = "edge",
-    endpointMachineTimeout = 100.milliseconds,
-    host = "0.0.0.0",
-    port = 2237,
-    portAutoIncrement = true,
-    portAutoIncrementMax = 100,
-    logLevel = LogLevel.Info,
-    logLevelColor = true,
-    logSuppressionList = Seq(),
-    publishBatchSize = 100,
-    publishBufferSize = 10000
-  )
-
   describe("Clock"):
     describe("Read"):
       it("replies current clock base"):

--- a/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/actors/sinks/ClockSpec.scala
@@ -17,7 +17,6 @@ import scala.util.Using
 class ClockSpec extends ActorTestBase:
   private val baseConfig = EdgeStaticConfig(
     actorMachineTimeout = 90.milliseconds,
-    clockInitialStashSize = 100,
     edgeIdPrefix = "edge",
     endpointMachineTimeout = 100.milliseconds,
     host = "0.0.0.0",
@@ -35,37 +34,27 @@ class ClockSpec extends ActorTestBase:
     describe("Read"):
       it("replies current clock base"):
         Using(ActorTestKit()): testKit =>
-          val clock = testKit.spawn(Clock(baseConfig))
-          val reader = testKit.createTestProbe[ClockBase]()
-
-          val clockBase = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
-          clock ! UpdateClockBase(clockBase)
-          clock ! Read(reader.ref)
-
-          assert(reader.receiveMessage() == clockBase)
-
-      it("replies a clock base after first update"):
-        Using(ActorTestKit()): testKit =>
-          val clock = testKit.spawn(Clock(baseConfig))
+          val clockBase1 = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
+          val clock = testKit.spawn(Clock(clockBase1))
           val reader = testKit.createTestProbe[ClockBase]()
 
           clock ! Read(reader.ref)
-          val clockBase = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
-          clock ! UpdateClockBase(clockBase)
+          assert(reader.receiveMessage() == clockBase1)
 
-          assert(reader.receiveMessage() == clockBase)
+          val clockBase2 = ClockBase(Timestamp(6, 5), Timestamp(4, 3), 2.1)
+          clock ! UpdateClockBase(clockBase2)
+          clock ! Read(reader.ref)
+          assert(reader.receiveMessage() == clockBase2)
 
     describe("UpdateClockBase"):
       it("distributes clock base to registered observers"):
         Using(ActorTestKit()): testKit =>
-          val clock = testKit.spawn(Clock(baseConfig))
+          val clockBase1 = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
+          val clock = testKit.spawn(Clock(clockBase1))
           val observer1 = testKit.createTestProbe[UpdateClockBase]()
           val observer2 = testKit.createTestProbe[UpdateClockBase]()
 
           testKit.system.receptionist ! Receptionist.register(observerKey, observer1.ref)
-
-          val clockBase1 = ClockBase(Timestamp(1, 2), Timestamp(3, 4), 5.6)
-          clock ! UpdateClockBase(clockBase1)
           assert(observer1.receiveMessage().clockBase == clockBase1)
 
           testKit.system.receptionist ! Receptionist.register(observerKey, observer2.ref)

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -16,11 +16,15 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              culling = true,
-              cullingMaxFirstAgents = 100,
-              expiration = false,
-              expirationCheckMachineInterval = 1.second,
-              expirationTimeout = 3.seconds
+              culling = ChartConfig.Culling(
+                enabled = true,
+                maxFirstAgents = 100
+              ),
+              expiration = ChartConfig.Expiration(
+                enabled = false,
+                checkMachineInterval = 1.second,
+                timeout = 3.seconds
+              )
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -52,7 +56,7 @@ class EdgeConfigSpec extends AnyFunSpec:
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"chart":{"culling":true,"cullingMaxFirstAgents":100,"expiration":false,"expirationCheckMachineInterval":"1s","expirationTimeout":"3s"},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
+          json == """{"dynamic":{"chart":{"culling":{"enabled":true,"maxFirstAgents":100},"expiration":{"checkMachineInterval":"1s","enabled":false,"timeout":"3s"}},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
         )
 
     describe("validated"):
@@ -60,11 +64,15 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              culling = false,
-              cullingMaxFirstAgents = 50,
-              expiration = true,
-              expirationCheckMachineInterval = 10.second,
-              expirationTimeout = 20.seconds
+              culling = ChartConfig.Culling(
+                enabled = false,
+                maxFirstAgents = 50
+              ),
+              expiration = ChartConfig.Expiration(
+                enabled = true,
+                checkMachineInterval = 10.second,
+                timeout = 20.seconds
+              )
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -104,11 +112,15 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              culling = true,
-              cullingMaxFirstAgents = -1,
-              expiration = false,
-              expirationCheckMachineInterval = -1.second,
-              expirationTimeout = -3.seconds
+              culling = ChartConfig.Culling(
+                enabled = true,
+                maxFirstAgents = -1
+              ),
+              expiration = ChartConfig.Expiration(
+                enabled = false,
+                checkMachineInterval = -1.second,
+                timeout = -3.seconds
+              )
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -142,9 +154,9 @@ class EdgeConfigSpec extends AnyFunSpec:
         assert(result.isInvalid)
         assert(
           result.swap.getOrElse(NonEmptyChain.one("")).toChain.toVector.toSet == Set(
-            "test.dynamic.chart.cullingMaxFirstAgents must be >= 0",
-            "test.dynamic.chart.expirationCheckMachineInterval must be > 0",
-            "test.dynamic.chart.expirationTimeout must be > 0",
+            "test.dynamic.chart.culling.maxFirstAgents must be >= 0",
+            "test.dynamic.chart.expiration.checkMachineInterval must be > 0",
+            "test.dynamic.chart.expiration.timeout must be > 0",
             "test.dynamic.coordinate.axis.{x, y, z} must contain (East or West) and (North or South) and (Up or Down)",
             "test.static.actorMachineTimeout must be > 0",
             "test.static.edgeIdPrefix: must match pattern [0-9a-zA-Z\\-_]+",

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -36,7 +36,6 @@ class EdgeConfigSpec extends AnyFunSpec:
           ),
           static = EdgeStaticConfig(
             actorMachineTimeout = 30.seconds,
-            clockInitialStashSize = 100,
             edgeIdPrefix = "test",
             endpointMachineTimeout = 10.seconds,
             host = "localhost",
@@ -53,7 +52,7 @@ class EdgeConfigSpec extends AnyFunSpec:
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"chart":{"culling":true,"cullingMaxFirstAgents":100,"expiration":false,"expirationCheckMachineInterval":"1s","expirationTimeout":"3s"},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
+          json == """{"dynamic":{"chart":{"culling":true,"cullingMaxFirstAgents":100,"expiration":false,"expirationCheckMachineInterval":"1s","expirationTimeout":"3s"},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
         )
 
     describe("validated"):
@@ -85,7 +84,6 @@ class EdgeConfigSpec extends AnyFunSpec:
           ),
           static = EdgeStaticConfig(
             actorMachineTimeout = 60.seconds,
-            clockInitialStashSize = 200,
             edgeIdPrefix = "valid",
             endpointMachineTimeout = 20.seconds,
             host = "0.0.0.0",
@@ -126,7 +124,6 @@ class EdgeConfigSpec extends AnyFunSpec:
           ),
           static = EdgeStaticConfig(
             actorMachineTimeout = 0.seconds,
-            clockInitialStashSize = 0,
             edgeIdPrefix = "",
             endpointMachineTimeout = 0.seconds,
             host = "",
@@ -145,17 +142,16 @@ class EdgeConfigSpec extends AnyFunSpec:
         assert(result.isInvalid)
         assert(
           result.swap.getOrElse(NonEmptyChain.one("")).toChain.toVector.toSet == Set(
-            "test.dynamic.coordinate.axis.{x, y, z} must contain (East or West) and (North or South) and (Up or Down)",
             "test.dynamic.chart.cullingMaxFirstAgents must be >= 0",
             "test.dynamic.chart.expirationCheckMachineInterval must be > 0",
             "test.dynamic.chart.expirationTimeout must be > 0",
+            "test.dynamic.coordinate.axis.{x, y, z} must contain (East or West) and (North or South) and (Up or Down)",
+            "test.static.actorMachineTimeout must be > 0",
             "test.static.edgeIdPrefix: must match pattern [0-9a-zA-Z\\-_]+",
+            "test.static.endpointMachineTimeout must be > 0",
             "test.static.host must not be empty",
             "test.static.port must be > 0",
             "test.static.portAutoIncrementMax must be >= 0",
-            "test.static.actorMachineTimeout must be > 0",
-            "test.static.endpointMachineTimeout must be > 0",
-            "test.static.clockInitialStashSize must be > 0",
             "test.static.publishBatchSize must be > 0",
             "test.static.publishBufferSize must be > 0"
           )

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -16,8 +16,11 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              edgeCulling = true,
-              maxFirstAgents = 100
+              culling = true,
+              cullingMaxFirstAgents = 100,
+              expiration = false,
+              expirationCheckMachineInterval = 1.second,
+              expirationTimeout = 3.seconds
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -50,7 +53,7 @@ class EdgeConfigSpec extends AnyFunSpec:
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"chart":{"edgeCulling":true,"maxFirstAgents":100},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
+          json == """{"dynamic":{"chart":{"culling":true,"cullingMaxFirstAgents":100,"expiration":false,"expirationCheckMachineInterval":"1s","expirationTimeout":"3s"},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
         )
 
     describe("validated"):
@@ -58,8 +61,11 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              edgeCulling = false,
-              maxFirstAgents = 50
+              culling = false,
+              cullingMaxFirstAgents = 50,
+              expiration = true,
+              expirationCheckMachineInterval = 10.second,
+              expirationTimeout = 20.seconds
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -100,8 +106,11 @@ class EdgeConfigSpec extends AnyFunSpec:
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
             chart = ChartConfig(
-              edgeCulling = true,
-              maxFirstAgents = -1
+              culling = true,
+              cullingMaxFirstAgents = -1,
+              expiration = false,
+              expirationCheckMachineInterval = -1.second,
+              expirationTimeout = -3.seconds
             ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
@@ -137,7 +146,9 @@ class EdgeConfigSpec extends AnyFunSpec:
         assert(
           result.swap.getOrElse(NonEmptyChain.one("")).toChain.toVector.toSet == Set(
             "test.dynamic.coordinate.axis.{x, y, z} must contain (East or West) and (North or South) and (Up or Down)",
-            "test.dynamic.chart.maxFirstAgents must be >= 0",
+            "test.dynamic.chart.cullingMaxFirstAgents must be >= 0",
+            "test.dynamic.chart.expirationCheckMachineInterval must be > 0",
+            "test.dynamic.chart.expirationTimeout must be > 0",
             "test.static.edgeIdPrefix: must match pattern [0-9a-zA-Z\\-_]+",
             "test.static.host must not be empty",
             "test.static.port must be > 0",

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -14,7 +14,7 @@ class EdgeConfigSpec extends AnyFunSpec:
     describe("toJson"):
       it("converts config to JSON string"):
         val config = EdgeConfig(
-          dynamic = DynamicEdgeConfig(
+          dynamic = EdgeDynamicConfig(
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -31,7 +31,7 @@ class EdgeConfigSpec extends AnyFunSpec:
               maxFirstAgents = 100
             )
           ),
-          static = StaticEdgeConfig(
+          static = EdgeStaticConfig(
             actorMachineTimeout = 30.seconds,
             clockInitialStashSize = 100,
             edgeIdPrefix = "test",
@@ -56,7 +56,7 @@ class EdgeConfigSpec extends AnyFunSpec:
     describe("validated"):
       it("returns valid config when all fields are valid"):
         val config = EdgeConfig(
-          dynamic = DynamicEdgeConfig(
+          dynamic = EdgeDynamicConfig(
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -77,7 +77,7 @@ class EdgeConfigSpec extends AnyFunSpec:
               maxFirstAgents = 50
             )
           ),
-          static = StaticEdgeConfig(
+          static = EdgeStaticConfig(
             actorMachineTimeout = 60.seconds,
             clockInitialStashSize = 200,
             edgeIdPrefix = "valid",
@@ -98,7 +98,7 @@ class EdgeConfigSpec extends AnyFunSpec:
 
       it("returns invalid with error messages when fields are invalid"):
         val config = EdgeConfig(
-          dynamic = DynamicEdgeConfig(
+          dynamic = EdgeDynamicConfig(
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -115,7 +115,7 @@ class EdgeConfigSpec extends AnyFunSpec:
               maxFirstAgents = -1
             )
           ),
-          static = StaticEdgeConfig(
+          static = EdgeStaticConfig(
             actorMachineTimeout = 0.seconds,
             clockInitialStashSize = 0,
             edgeIdPrefix = "",

--- a/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
+++ b/arktwin/edge/src/test/scala/arktwin/edge/configs/EdgeConfigSpec.scala
@@ -15,6 +15,10 @@ class EdgeConfigSpec extends AnyFunSpec:
       it("converts config to JSON string"):
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
+            chart = ChartConfig(
+              edgeCulling = true,
+              maxFirstAgents = 100
+            ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -25,10 +29,6 @@ class EdgeConfigSpec extends AnyFunSpec:
               rotation = QuaternionConfig,
               lengthUnit = CoordinateConfig.LengthUnit.Meter,
               speedUnit = CoordinateConfig.SpeedUnit.MeterPerSecond
-            ),
-            culling = CullingConfig(
-              edgeCulling = true,
-              maxFirstAgents = 100
             )
           ),
           static = EdgeStaticConfig(
@@ -50,13 +50,17 @@ class EdgeConfigSpec extends AnyFunSpec:
         val json = config.toJson
 
         assert(
-          json == """{"dynamic":{"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}},"culling":{"edgeCulling":true,"maxFirstAgents":100}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
+          json == """{"dynamic":{"chart":{"edgeCulling":true,"maxFirstAgents":100},"coordinate":{"axis":{"xDirection":{"type":"East"},"yDirection":{"type":"North"},"zDirection":{"type":"Up"}},"centerOrigin":{"x":0.0,"y":0.0,"z":0.0},"lengthUnit":{"type":"Meter"},"rotation":{"type":"QuaternionConfig"},"speedUnit":{"type":"MeterPerSecond"}}},"static":{"actorMachineTimeout":"30s","clockInitialStashSize":100,"edgeIdPrefix":"test","endpointMachineTimeout":"10s","host":"localhost","logLevel":{"type":"Info"},"logLevelColor":true,"logSuppressionList":[],"port":8081,"portAutoIncrement":false,"portAutoIncrementMax":0,"publishBatchSize":50,"publishBufferSize":500}}"""
         )
 
     describe("validated"):
       it("returns valid config when all fields are valid"):
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
+            chart = ChartConfig(
+              edgeCulling = false,
+              maxFirstAgents = 50
+            ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -71,10 +75,6 @@ class EdgeConfigSpec extends AnyFunSpec:
               ),
               lengthUnit = CoordinateConfig.LengthUnit.Millimeter,
               speedUnit = CoordinateConfig.SpeedUnit.KilometerPerHour
-            ),
-            culling = CullingConfig(
-              edgeCulling = false,
-              maxFirstAgents = 50
             )
           ),
           static = EdgeStaticConfig(
@@ -99,6 +99,10 @@ class EdgeConfigSpec extends AnyFunSpec:
       it("returns invalid with error messages when fields are invalid"):
         val config = EdgeConfig(
           dynamic = EdgeDynamicConfig(
+            chart = ChartConfig(
+              edgeCulling = true,
+              maxFirstAgents = -1
+            ),
             coordinate = CoordinateConfig(
               axis = AxisConfig(
                 xDirection = AxisConfig.Direction.East,
@@ -109,10 +113,6 @@ class EdgeConfigSpec extends AnyFunSpec:
               rotation = QuaternionConfig,
               lengthUnit = CoordinateConfig.LengthUnit.Meter,
               speedUnit = CoordinateConfig.SpeedUnit.MeterPerSecond
-            ),
-            culling = CullingConfig(
-              edgeCulling = true,
-              maxFirstAgents = -1
             )
           ),
           static = EdgeStaticConfig(
@@ -137,7 +137,7 @@ class EdgeConfigSpec extends AnyFunSpec:
         assert(
           result.swap.getOrElse(NonEmptyChain.one("")).toChain.toVector.toSet == Set(
             "test.dynamic.coordinate.axis.{x, y, z} must contain (East or West) and (North or South) and (Up or Down)",
-            "test.dynamic.culling.maxFirstAgents must be >= 0",
+            "test.dynamic.chart.maxFirstAgents must be >= 0",
             "test.static.edgeIdPrefix: must match pattern [0-9a-zA-Z\\-_]+",
             "test.static.host must not be empty",
             "test.static.port must be > 0",


### PR DESCRIPTION
This PR introduces a neighbor expiration feature to the Chart actor and refactors the configuration structure to provide a more organized and nested approach. The changes improve the management of stale agent data and configuration consistency across the codebase.

# Key Changes

- Neighbor Expiration Feature: Added automatic expiration of inactive neighbor agents in the Chart actor
    - Configurable via chart.expiration settings with enabled, checkMachineInterval, and timeout parameters
    - Prevents memory accumulation from disconnected or inactive agents
    - Includes comprehensive test coverage for expiration behavior
- Configuration Refactoring:
    - Renamed configuration classes to follow consistent naming pattern (`CenterConfig` → `CenterStaticConfig/CenterDynamicConfig`, `EdgeConfig → EdgeStaticConfig/EdgeDynamicConfig`)
    - Restructured culling configuration under nested chart configuration with separate culling and expiration sections
    - Renamed API endpoint from `/api/edge/config/culling` to `/api/edge/config/chart `to reflect broader scope
- Clock Actor Improvements:
    - Removed stash pattern from Clock actor for simpler initialization
    - Added Read RPC method to Clock service for fetching initial clock state
    - Edge now initializes with clock base value on startup
- Code Organization:
    - Alphabetically sorted Clock actor message handlers for better readability
    - Improved Chart actor structure with clearer separation of concerns

# Breaking Changes

- API endpoint renamed: `/api/edge/config/culling → `/api/edge/config/chart`
- Configuration structure changed: `dynamic.culling` → `dynamic.chart` with nested culling and expiration sections