### PR TITLE
Pin GitHub Actions versions and configure Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -12,6 +14,8 @@ updates:
     directory: "/arktwin/viewer/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     open-pull-requests-limit: 30

--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -12,10 +12,10 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
       
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
-      - uses: scalacenter/sbt-dependency-submission@v3
+      - uses: scalacenter/sbt-dependency-submission@v3.1.0
         with:
           working-directory: arktwin

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -24,24 +24,24 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
         with:
           path: arktwin
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.0.0
         with:
           java-version: 21
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/arktwin/build.sbt
 
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
       - name: Generate OpenAPI YAML files
         working-directory: arktwin/arktwin
         run: sbt "edge/run generate-openapi-center ../../pages/dist/swagger-ui/center/arktwin-center.yaml" "edge/run generate-openapi-edge ../../pages/dist/swagger-ui/edge/arktwin-edge.yaml"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
         with:
           repository: swagger-api/swagger-ui
           ref: v5.17.14
@@ -53,11 +53,11 @@ jobs:
           cp swagger-ui/dist/* arktwin/pages/dist/swagger-ui/bundle
           rm arktwin/pages/dist/swagger-ui/bundle/index.html
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v5.0.0
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: arktwin/pages/dist
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v4.0.5
         id: deployment

--- a/.github/workflows/scala-ci.yaml
+++ b/.github/workflows/scala-ci.yaml
@@ -12,16 +12,16 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.0.0
         with:
           java-version: 21
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
       
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
       # check before automatic execution at compile time
       - name: sbt scalafixAll --check
@@ -51,16 +51,16 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.0.0
         with:
           java-version: 21
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
 
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
       - name: sbt compile
         working-directory: arktwin
@@ -85,16 +85,16 @@ jobs:
   license-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.0.0
         with:
           java-version: 21
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
 
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
       - name: sbt center/licenseCheck
         working-directory: arktwin
@@ -107,18 +107,18 @@ jobs:
   changelogs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.0.0
         with:
           java-version: 21
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
 
-      - uses: sbt/setup-sbt@v1
+      - uses: sbt/setup-sbt@v1.1.12
 
       - name: Generate OpenAPI YAML files
         working-directory: arktwin
@@ -174,13 +174,13 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6.18.0
         with:
           file: docker/center.dockerfile
           tags: arktwin-center
           push: false
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6.18.0
         with:
           file: docker/edge.dockerfile
           tags: arktwin-edge

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -12,9 +12,9 @@ jobs:
   license-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version-file: arktwin/viewer/package.json
           cache: npm


### PR DESCRIPTION
- Pin all GitHub Actions to specific versions for reproducibility
- Add 7-day cooldown period to Dependabot configurations
- Change GitHub Actions update frequency from weekly to monthly