### PR TITLE
Update Java version from 21 to 25

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/arktwin/build.sbt

--- a/.github/workflows/scala-ci.yaml
+++ b/.github/workflows/scala-ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: sbt
           cache-dependency-path: arktwin/build.sbt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ However, each agent-based software can connect to ArkTwin via local REST API pro
 
 ### JAR
 
-1. install Java Development Kit (recommended: [Eclipse Temurin 21 LTS](https://adoptium.net/temurin/releases/?variant=openjdk21&jvmVariant=hotspot))
+1. install Java Development Kit (recommended: [Eclipse Temurin 25 LTS](https://adoptium.net/temurin/releases/?variant=openjdk25&jvmVariant=hotspot))
 1. install [sbt](https://www.scala-sbt.org/download)
 1. install [Node.js](https://nodejs.org/en/download/package-manager) (recommended: v24)
 1. `git checkout <release tag>`

--- a/docker/center.dockerfile
+++ b/docker/center.dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21 AS jre-build
+FROM eclipse-temurin:25 AS jre-build
 RUN $JAVA_HOME/bin/jlink \
         --add-modules java.se,jdk.httpserver,jdk.jcmd,jdk.unsupported \
         --strip-debug \
@@ -7,7 +7,7 @@ RUN $JAVA_HOME/bin/jlink \
         --compress=zip-9 \
         --output /javaruntime
 
-FROM sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.11.6_3.7.3 AS jar-build
+FROM sbtscala/scala-sbt:eclipse-temurin-25_36_1.11.7_3.7.3 AS jar-build
 WORKDIR /arktwin/
 COPY arktwin/ /arktwin/
 RUN sbt center/assembly

--- a/docker/edge.dockerfile
+++ b/docker/edge.dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21 AS jre-build
+FROM eclipse-temurin:25 AS jre-build
 RUN $JAVA_HOME/bin/jlink \
         --add-modules java.se,jdk.httpserver,jdk.jcmd,jdk.unsupported \
         --strip-debug \
@@ -7,7 +7,7 @@ RUN $JAVA_HOME/bin/jlink \
         --compress=zip-9 \
         --output /javaruntime
 
-FROM sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.11.6_3.7.3 AS jar-build
+FROM sbtscala/scala-sbt:eclipse-temurin-25_36_1.11.7_3.7.3 AS jar-build
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install -y nodejs


### PR DESCRIPTION
## Summary

This PR upgrades the Java version from 21 to 25 across all environments (GitHub Actions workflows, Docker images, and documentation).

## Changes

- Update GitHub Actions workflows to use Java 25
    - `.github/workflows/github-pages.yaml`
    - `.github/workflows/scala-ci.yaml` (test, coverage, gatling, and publish jobs)
- Update Docker base images to Eclipse Temurin 25
    - `docker/center.dockerfile`
    - `docker/edge.dockerfile`
- Update sbt/Scala build images to `eclipse-temurin-25_36_1.11.7_3.7.3` (also upgrades sbt from 1.11.6 to 1.11.7)
- Update README.md to recommend Eclipse Temurin 25 LTS