### PR TITLE
Remove ZGenerational JVM option for Java 24 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ However, each agent-based software can connect to ArkTwin via local REST API pro
 
 ### JAR
 
-- `java [-Dconfig.file=center.conf] -XX:+UseZGC -XX:+ZGenerational -jar arktwin-center.jar`
-- `ARKTWIN_CENTER_STATIC_HOST=<CENTER_HOST> java [-Dconfig.file=edge.conf] -XX:+UseZGC -XX:+ZGenerational -jar arktwin-edge.jar [arg]...`
+- `java [-Dconfig.file=center.conf] -XX:+UseZGC -jar arktwin-center.jar`
+- `ARKTWIN_CENTER_STATIC_HOST=<CENTER_HOST> java [-Dconfig.file=edge.conf] -XX:+UseZGC -jar arktwin-edge.jar [arg]...`
 
 ### Edge Optional Command Arguments
 

--- a/docker/center.dockerfile
+++ b/docker/center.dockerfile
@@ -24,4 +24,4 @@ RUN mkdir /opt/arktwin/ && \
     touch /etc/opt/arktwin/center.conf
 COPY --from=jre-build /javaruntime $JAVA_HOME
 COPY --from=jar-build /arktwin/center/target/scala-3.7.3/arktwin-center.jar /opt/arktwin/arktwin-center.jar
-ENTRYPOINT ["java", "-Dconfig.file=/etc/opt/arktwin/center.conf", "-XX:MaxRAMPercentage=75", "-XX:+UseZGC", "-XX:+ZGenerational", "-jar", "/opt/arktwin/arktwin-center.jar"]
+ENTRYPOINT ["java", "-Dconfig.file=/etc/opt/arktwin/center.conf", "-XX:MaxRAMPercentage=75", "-XX:+UseZGC", "-jar", "/opt/arktwin/arktwin-center.jar"]

--- a/docker/edge.sh
+++ b/docker/edge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 if [ "$#" -eq 0 ]; then
-  java -Dconfig.file=/etc/opt/arktwin/edge.conf -XX:MaxRAMPercentage=75 -XX:+UseZGC -XX:+ZGenerational -jar /opt/arktwin/arktwin-edge.jar &
+  java -Dconfig.file=/etc/opt/arktwin/edge.conf -XX:MaxRAMPercentage=75 -XX:+UseZGC -jar /opt/arktwin/arktwin-edge.jar &
   PID=$!
   while [ ! -f /var/opt/arktwin/edge.shutdown ]; do
     sleep 1
@@ -8,5 +8,5 @@ if [ "$#" -eq 0 ]; then
   kill -TERM $PID
   rm /var/opt/arktwin/edge.shutdown
 else
-  java -Dconfig.file=/etc/opt/arktwin/edge.conf -XX:MaxRAMPercentage=75 -XX:+UseZGC -XX:+ZGenerational -jar /opt/arktwin/arktwin-edge.jar $@
+  java -Dconfig.file=/etc/opt/arktwin/edge.conf -XX:MaxRAMPercentage=75 -XX:+UseZGC -jar /opt/arktwin/arktwin-edge.jar $@
 fi


### PR DESCRIPTION
This PR removes the -XX:+ZGenerational JVM option from all Java launch configurations, as this option has been removed in Java 24.0.

# Changes

- Updated README.md to remove -XX:+ZGenerational from JAR execution examples
- Updated Docker center configuration (docker/center.dockerfile) to remove the flag
- Updated Docker edge startup script (docker/edge.sh) to remove the flag

# Context

The ZGenerational option was part of the Z Garbage Collector (ZGC) configuration in earlier Java versions, but support for this option was removed in Java 24.0.
This change ensures compatibility with newer Java versions while maintaining ZGC usage via -XX:+UseZGC.