### PR TITLE
Fix CVE-2023-45853 by upgrading Docker base image to debian:trixie-slim

### DIFF
--- a/docker/center.dockerfile
+++ b/docker/center.dockerfile
@@ -12,7 +12,7 @@ WORKDIR /arktwin/
 COPY arktwin/ /arktwin/
 RUN sbt center/assembly
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get update && \

--- a/docker/edge.dockerfile
+++ b/docker/edge.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /arktwin/
 COPY arktwin/ /arktwin/
 RUN sbt viewer/package edge/assembly
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- Upgrade Docker runtime base image from `debian:bookworm-slim` to `debian:trixie-slim`
- Fixes CVE-2023-45853 (Critical, CVSS 9.8): integer overflow in MiniZip (zlib)
- `zlib1g` in bookworm is 1.2.13 (will_not_fix by Debian); trixie provides 1.3.1 with the fix

## Changes
- `docker/center.dockerfile`: `debian:bookworm-slim` → `debian:trixie-slim`
- `docker/edge.dockerfile`: `debian:bookworm-slim` → `debian:trixie-slim`

## Test plan
- [x] Build center image: `docker build -f docker/center.dockerfile -t arktwin-center:test .`
- [x] Build edge image: `docker build -f docker/edge.dockerfile -t arktwin-edge:test .`
- [x] Verify zlib version in image: `docker run --rm arktwin-center:test dpkg -l zlib1g`
- [x] Run vulnerability scan to confirm CVE-2023-45853 is resolved