### PR TITLE
Add HEALTHCHECK/EXPOSE to Docker images and drop unused jq

### DIFF
--- a/docker/center.dockerfile
+++ b/docker/center.dockerfile
@@ -24,4 +24,6 @@ RUN mkdir /opt/arktwin/ && \
     touch /etc/opt/arktwin/center.conf
 COPY --from=jre-build /javaruntime $JAVA_HOME
 COPY --from=jar-build /arktwin/center/target/scala-3.8.3/arktwin-center.jar /opt/arktwin/arktwin-center.jar
+EXPOSE 2236
+HEALTHCHECK --start-period=5s CMD curl -f http://localhost:2236/health || exit 1
 ENTRYPOINT ["java", "-Dconfig.file=/etc/opt/arktwin/center.conf", "-XX:MaxRAMPercentage=75", "-XX:+UseZGC", "-jar", "/opt/arktwin/arktwin-center.jar"]

--- a/docker/center.dockerfile
+++ b/docker/center.dockerfile
@@ -16,7 +16,7 @@ FROM debian:trixie-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get update && \
-    apt-get install -y curl jq && \
+    apt-get install -y curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir /opt/arktwin/ && \

--- a/docker/edge.dockerfile
+++ b/docker/edge.dockerfile
@@ -28,4 +28,6 @@ RUN mkdir /opt/arktwin/ && \
 COPY --from=jre-build /javaruntime $JAVA_HOME
 COPY --from=jar-build /arktwin/edge/target/scala-3.8.3/arktwin-edge.jar /opt/arktwin/arktwin-edge.jar
 COPY docker/edge.sh /opt/arktwin/entrypoint.sh
+EXPOSE 2237
+HEALTHCHECK --start-period=5s CMD curl -f http://localhost:2237/health || exit 1
 ENTRYPOINT ["/opt/arktwin/entrypoint.sh"]

--- a/docker/edge.dockerfile
+++ b/docker/edge.dockerfile
@@ -19,7 +19,7 @@ FROM debian:trixie-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get update && \
-    apt-get install -y curl jq && \
+    apt-get install -y curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir /opt/arktwin/ && \


### PR DESCRIPTION
- Add `EXPOSE` and `HEALTHCHECK` directives to the center (port 2236) and edge (port 2237) Docker images so container runtimes can advertise the service port and report container health via the `/health` endpoint.
- Drop the `jq` package from both images since it is no longer used, slightly shrinking the resulting images.